### PR TITLE
CLI for plotting MAE,MSE,RMSE,SIE metrics for forecasts

### DIFF
--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -385,10 +385,10 @@ def sic_error_video(fc_da: object,
     im3 = maps[2].imshow(diff_plot, 
                          vmin=-1, vmax=1, cmap="RdBu_r")
 
-    tic = maps[0].set_title("IceNet {}".format(
-        pd.to_datetime(fc_da.isel(time=leadtime).time.values).strftime("%d/%m/%Y")))
-    tio = maps[1].set_title("OSISAF Obs {}".format(
-        pd.to_datetime(obs_da.isel(time=leadtime).time.values).strftime("%d/%m/%Y")))
+    tic = maps[0].set_title("IceNet "
+                            f"{pd.to_datetime(fc_da.isel(time=leadtime).time.values).strftime('%d/%m/%Y')}")
+    tio = maps[1].set_title("OSISAF Obs "
+                            f"{pd.to_datetime(obs_da.isel(time=leadtime).time.values).strftime('%d/%m/%Y')}")
     maps[2].set_title("Diff")
 
     p0 = maps[0].get_position().get_points().flatten()
@@ -410,16 +410,16 @@ def sic_error_video(fc_da: object,
     fig.subplots_adjust(hspace=0.2, wspace=0.2)
 
     def update(date):
-        logging.debug("Plotting {}".format(date))
+        logging.debug(f"Plotting {date}")
 
         fc_plot = fc_da.isel(time=date).to_numpy()
         obs_plot = obs_da.isel(time=date).to_numpy()
         diff_plot = diff.isel(time=date).to_numpy()
         
-        tic.set_text("IceNet {}".format(
-            pd.to_datetime(fc_da.isel(time=date).time.values).strftime("%d/%m/%Y")))
-        tio.set_text("OSISAF Obs {}".format(
-            pd.to_datetime(obs_da.isel(time=date).time.values).strftime("%d/%m/%Y")))
+        tic.set_text("IceNet "
+                     f"{pd.to_datetime(fc_da.isel(time=date).time.values).strftime('%d/%m/%Y')}")
+        tio.set_text("OSISAF Obs "
+                     f"{pd.to_datetime(obs_da.isel(time=date).time.values).strftime('%d/%m/%Y')}")
 
         im1.set_data(fc_plot)
         im2.set_data(obs_plot)

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
             "icenet_plot_sic_error = icenet.plotting.forecast:sic_error",
             "icenet_plot_bin_accuracy = "
             "icenet.plotting.forecast:binary_accuracy",
+            "icenet_plot_metrics = icenet.plotting.forecast:metric_plots",
 
             "icenet_video_data = icenet.plotting.video:data_cli",
 

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ setup(
             "icenet_plot_sic_error = icenet.plotting.forecast:sic_error",
             "icenet_plot_bin_accuracy = "
             "icenet.plotting.forecast:binary_accuracy",
+            "icenet_plot_sie_error = icenet.plotting.forecast:sie_error",
             "icenet_plot_metrics = icenet.plotting.forecast:metric_plots",
 
             "icenet_video_data = icenet.plotting.video:data_cli",


### PR DESCRIPTION
Partly working through #95 and #93.
This PR will close #108 too.

To do:
- [x] add functionality to plot metrics based on the raw SIC error (MAE, MSE and RMSE)
  - [x] allow comparison to different forecasts
- [x] add functionality to plot SIE error
  - [x] allow comparison to different forecasts
- [x] allow for different SIC thresholds for binary accuracy and SIE metrics (default is 15%)

**MAE, MSE, RMSE metric plots**

```
icenet_plot_metrics north preds.nc 2016-03-31 -m MSE,MAE,RMSE
```
creates the following plot
![output](https://user-images.githubusercontent.com/44200705/220948023-e4f213c2-b693-47a2-b431-980149f4886d.png)

(can choose which metrics to plot in the command, but by default plots them all).

Will work on implementing CLI for plotting SIE metric next...