### PR TITLE
Fixes #133: Make it optional to save outputs for debugging when predicting

### DIFF
--- a/icenet/model/predict.py
+++ b/icenet/model/predict.py
@@ -148,16 +148,16 @@ def run_prediction(network,
     if save_args:
         logging.debug("Saving loader generated data for reference...")
         for date, output, directory in \
-                ((date, net_input, "input"),
-                (date, net_output, "outputs"),
-                (date, sample_weights, "weights")):
-            output_directory = os.path.join(output_folder, "loader", directory)
-            os.makedirs(output_directory, exist_ok=True)
-            loader_output_path = os.path.join(output_directory,
-                                            date.strftime("%Y_%m_%d.npy"))
-
+            ((date, net_input, "input"),
+             (date, net_output, "outputs"),
+             (date, sample_weights, "weights")):
+                output_directory = os.path.join(output_folder, "loader", directory)
+                os.makedirs(output_directory, exist_ok=True)
+                loader_output_path = os.path.join(output_directory,
+                                                  date.strftime("%Y_%m_%d.npy"))
+                
             logging.info("Saving {} - generated {} {}".
-                        format(date, directory, output.shape))
+                         format(date, directory, output.shape))
             np.save(loader_output_path, output)
 
     return output_path

--- a/icenet/model/predict.py
+++ b/icenet/model/predict.py
@@ -26,6 +26,7 @@ def predict_forecast(
     n_filters_factor: float = 1 / 8,
     network_folder: object = None,
     output_folder: object = None,
+    save_args: bool = False,
     seed: int = 42,
     start_dates: object = tuple([dt.datetime.now().date()]),
     test_set: bool = False,
@@ -39,6 +40,7 @@ def predict_forecast(
     :param n_filters_factor:
     :param network_folder:
     :param output_folder:
+    :param save_args:
     :param seed:
     :param start_dates:
     :param test_set:
@@ -72,10 +74,14 @@ def predict_forecast(
         logging.info("Generating forecast inputs from processed/ files")
 
         for date in start_dates:
-            run_prediction(network,
-                           date,
-                           output_folder,
-                           *dl.generate_sample(date, prediction=True))
+            net_input, net_output, sample_weights = dl.generate_sample(date, prediction=True)
+            run_prediction(network=network,
+                           date=date,
+                           output_folder=output_folder,
+                           net_input=net_input,
+                           net_output=net_output,
+                           sample_weights=sample_weights,
+                           save_args=save_args)
     else:
         # TODO: This is horrible behaviour, rethink and refactor: we should
         #  be able to pull from the test set in a nicer and more efficient
@@ -112,16 +118,22 @@ def predict_forecast(
             logging.info("Processing test batch {}, item {} (date {})".format(
                 batch + 1, arr_idx, test_dates[idx]))
 
-            run_prediction(network,
-                           test_dates[idx],
-                           output_folder,
-                           x[arr_idx, ...],
-                           y[arr_idx, ...],
-                           sw[arr_idx, ...])
+            run_prediction(network=network,
+                           date=test_dates[idx],
+                           output_folder=output_folder,
+                           net_input=x[arr_idx, ...],
+                           net_output=y[arr_idx, ...],
+                           sample_weights=sw[arr_idx, ...],
+                           save_args=save_args)
 
 
-def run_prediction(network, date, output_folder,
-                   net_input, net_output, sample_weights):
+def run_prediction(network,
+                   date,
+                   output_folder,
+                   net_input,
+                   net_output,
+                   sample_weights,
+                   save_args):
     logging.info("Running prediction {}".format(date))
     pred = network(tf.convert_to_tensor([net_input]), training=False)
 
@@ -133,20 +145,20 @@ def run_prediction(network, date, output_folder,
     logging.info("Saving {} - forecast output {}".format(date, pred.shape))
     np.save(output_path, pred)
 
-    logging.debug("Saving loader generated data for reference...")
+    if save_args:
+        logging.debug("Saving loader generated data for reference...")
+        for date, output, directory in \
+                ((date, net_input, "input"),
+                (date, net_output, "outputs"),
+                (date, sample_weights, "weights")):
+            output_directory = os.path.join(output_folder, "loader", directory)
+            os.makedirs(output_directory, exist_ok=True)
+            loader_output_path = os.path.join(output_directory,
+                                            date.strftime("%Y_%m_%d.npy"))
 
-    for date, output, directory in \
-            ((date, net_input, "input"),
-             (date, net_output, "outputs"),
-             (date, sample_weights, "weights")):
-        output_directory = os.path.join(output_folder, "loader", directory)
-        os.makedirs(output_directory, exist_ok=True)
-        loader_output_path = os.path.join(output_directory,
-                                          date.strftime("%Y_%m_%d.npy"))
-
-        logging.info("Saving {} - generated {} {}".
-                     format(date, directory, output.shape))
-        np.save(loader_output_path, output)
+            logging.info("Saving {} - generated {} {}".
+                        format(date, directory, output.shape))
+            np.save(loader_output_path, output)
 
     return output_path
 
@@ -177,8 +189,9 @@ def get_args():
     ap.add_argument("-i", "--train-identifier", dest="ident",
                     help="Train dataset identifier", type=str, default=None)
     ap.add_argument("-n", "--n-filters-factor", type=float, default=1.)
-    ap.add_argument("-t", "--testset", default=False, action="store_true")
+    ap.add_argument("-t", "--testset", action="store_true", default=False)
     ap.add_argument("-v", "--verbose", action="store_true", default=False)
+    ap.add_argument("-s", "--save_args", action="store_true", default=False)
 
     return ap.parse_args()
 
@@ -203,11 +216,10 @@ def main():
                      # FIXME: this is turning into a mapping mess,
                      #  do we need to retain the train SD name in the
                      #  network?
-                     dataset_name=
-                     args.ident if args.ident else args.dataset,
-                     n_filters_factor=
-                     args.n_filters_factor,
+                     dataset_name=args.ident if args.ident else args.dataset,
+                     n_filters_factor=args.n_filters_factor,
                      output_folder=output_folder,
+                     save_args=args.save_args,
                      seed=args.seed,
                      start_dates=dates,
                      test_set=args.testset)

--- a/icenet/model/predict.py
+++ b/icenet/model/predict.py
@@ -147,18 +147,17 @@ def run_prediction(network,
 
     if save_args:
         logging.debug("Saving loader generated data for reference...")
-        for date, output, directory in \
-            ((date, net_input, "input"),
-             (date, net_output, "outputs"),
-             (date, sample_weights, "weights")):
-                output_directory = os.path.join(output_folder, "loader", directory)
-                os.makedirs(output_directory, exist_ok=True)
-                loader_output_path = os.path.join(output_directory,
-                                                  date.strftime("%Y_%m_%d.npy"))
-                
-                logging.info("Saving {} - generated {} {}".
-                             format(date, directory, output.shape))
-                np.save(loader_output_path, output)
+        for date, output, directory in ((date, net_input, "input"),
+                                        (date, net_output, "outputs"),
+                                        (date, sample_weights, "weights")):
+            output_directory = os.path.join(output_folder, "loader", directory)
+            os.makedirs(output_directory, exist_ok=True)
+            loader_output_path = os.path.join(output_directory,
+                                                date.strftime("%Y_%m_%d.npy"))
+            
+            logging.info("Saving {} - generated {} {}".
+                            format(date, directory, output.shape))
+            np.save(loader_output_path, output)
 
     return output_path
 

--- a/icenet/model/predict.py
+++ b/icenet/model/predict.py
@@ -156,9 +156,9 @@ def run_prediction(network,
                 loader_output_path = os.path.join(output_directory,
                                                   date.strftime("%Y_%m_%d.npy"))
                 
-            logging.info("Saving {} - generated {} {}".
-                         format(date, directory, output.shape))
-            np.save(loader_output_path, output)
+                logging.info("Saving {} - generated {} {}".
+                             format(date, directory, output.shape))
+                np.save(loader_output_path, output)
 
     return output_path
 


### PR DESCRIPTION
Fix for #133.

By default, when we're running predictions, we no longer save weights, inputs and raw outputs (which are useful for debugging). In particular, I introduce the `save_args` argument to `predict_forecast` and `run_prediction` functions. The CLI command for prediction, `icenet_predict`, has a new flag `-s` or `--save_args`. When called, it will save these outputs, but otherwise does not.

Will help alleviate some storage issues when predicting.