### PR TITLE
#181: Fix n_forecast_days consistency

### DIFF
--- a/icenet/data/cli.py
+++ b/icenet/data/cli.py
@@ -119,6 +119,10 @@ def download_args(choices: object = None,
 
     if workers:
         ap.add_argument("-w", "--workers", default=8, type=int)
+    
+    ap.add_argument("-p", "--parallel-opens",
+                    default=False, action="store_true",
+                    help="Allow xarray mfdataset to work with parallel opens")
 
     ap.add_argument("-d", "--dont-delete", dest="delete",
                     action="store_false", default=True)

--- a/icenet/data/dataset.py
+++ b/icenet/data/dataset.py
@@ -49,6 +49,7 @@ class IceNetDataSet(SplittingMixin, DataCollection):
         self._counts = self._config["counts"]
         self._dtype = getattr(np, self._config["dtype"])
         self._loader_config = self._config["loader_config"]
+        self._generate_workers = self._config["generate_workers"]
         self._n_forecast_days = self._config["n_forecast_days"]
         self._num_channels = self._config["num_channels"]
         self._shape = tuple(self._config["shape"])
@@ -84,16 +85,22 @@ class IceNetDataSet(SplittingMixin, DataCollection):
         else:
             raise OSError("{} not found".format(path))
 
-    def get_data_loader(self):
+    def get_data_loader(self, n_forecast_days = None, generate_workers = None):
         """
 
         :return:
         """
+        if n_forecast_days is None:
+            n_forecast_days = self._config["n_forecast_days"]
+        if generate_workers is None:
+            generate_workers = self._config["generate_workers"]
         loader = IceNetDataLoaderFactory().create_data_loader(
             "dask",
             self.loader_config,
             self.identifier,
             self._config["var_lag"],
+            n_forecast_days=n_forecast_days,
+            generate_workers=generate_workers,
             dataset_config_path=os.path.dirname(
                 self._configuration_path),
             loss_weight_days=self._config[
@@ -103,7 +110,8 @@ class IceNetDataSet(SplittingMixin, DataCollection):
                 "output_batch_size"],
             south=self.south,
             var_lag_override=self._config[
-                "var_lag_override"])
+                "var_lag_override"],
+        )
         return loader
 
     @property

--- a/icenet/data/loaders/base.py
+++ b/icenet/data/loaders/base.py
@@ -302,6 +302,7 @@ class IceNetBaseDataLoader(Generator):
             # For recreating this dataloader
             # "dataset_config_path = ".",
             "dataset_path":     self._path if network_dataset else False,
+            "generate_workers": self.workers,
             "loss_weight_days": self._loss_weight_days,
             "output_batch_size": self._output_batch_size,
             "var_lag":          self._var_lag,

--- a/icenet/data/loaders/dask.py
+++ b/icenet/data/loaders/dask.py
@@ -421,6 +421,7 @@ def generate_sample(forecast_date: object,
     y = da.zeros((*shape, n_forecast_days, 1), dtype=dtype)
     sample_weights = da.zeros((*shape, n_forecast_days, 1), dtype=dtype)
     
+    
     if not prediction:
         try:
             sample_output = var_ds.siconca_abs.sel(time=forecast_dts)

--- a/icenet/data/loaders/dask.py
+++ b/icenet/data/loaders/dask.py
@@ -420,7 +420,7 @@ def generate_sample(forecast_date: object,
 
     y = da.zeros((*shape, n_forecast_days, 1), dtype=dtype)
     sample_weights = da.zeros((*shape, n_forecast_days, 1), dtype=dtype)
-
+    
     if not prediction:
         try:
             sample_output = var_ds.siconca_abs.sel(time=forecast_dts)

--- a/icenet/data/sic/osisaf.py
+++ b/icenet/data/sic/osisaf.py
@@ -190,7 +190,8 @@ invalid_sic_days = {
         dt.date(1984, 11, 19),
         dt.date(1984, 11, 21),
         dt.date(1985, 7, 23),
-        *pd.date_range(dt.date(1986, 7, 2), dt.date(1986, 11, 1)),
+        *[d.date() for d in
+          pd.date_range(dt.date(1986, 7, 2), dt.date(1986, 11, 1))],
         dt.date(1990, 8, 14),
         dt.date(1990, 8, 15),
         dt.date(1990, 8, 24),

--- a/icenet/data/sic/osisaf.py
+++ b/icenet/data/sic/osisaf.py
@@ -282,6 +282,7 @@ class SICDownloader(Downloader):
                  delete_tempfiles: bool = True,
                  download: bool = True,
                  dtype: object = np.float32,
+                 parallel_opens: bool = True,
                  **kwargs):
         super().__init__(*args, identifier="osisaf", **kwargs)
 
@@ -290,6 +291,7 @@ class SICDownloader(Downloader):
         self._delete = delete_tempfiles
         self._download = download
         self._dtype = dtype
+        self._parallel_opens = parallel_opens
         self._invalid_dates = invalid_sic_days[self.hemisphere] + \
             list(additional_invalid_dates)
         self._masks = Masks(north=self.north, south=self.south)
@@ -341,6 +343,7 @@ class SICDownloader(Downloader):
 
             # We won't hold onto an active dataset during network I/O
             extant_ds.close()
+
         # End filtering
 
         while len(dt_arr):
@@ -437,7 +440,7 @@ class SICDownloader(Downloader):
                                    drop_variables=var_remove_list,
                                    engine="netcdf4",
                                    chunks=dict(time=self._chunk_size,),
-                                   parallel=True)
+                                   parallel=self._parallel_opens)
 
             logging.debug("Processing out extraneous data")
 
@@ -516,7 +519,7 @@ class SICDownloader(Downloader):
                                combine="nested",
                                concat_dim="time",
                                chunks=dict(time=self._chunk_size, ),
-                               parallel=True)
+                               parallel=self._parallel_opens)
         return self._missing_dates(ds.ice_conc)
 
     def _missing_dates(self, da: object) -> object:
@@ -647,6 +650,7 @@ def main():
         delete_tempfiles=args.delete,
         north=args.hemisphere == "north",
         south=args.hemisphere == "south",
+        parallel_opens=args.parallel_opens,
     )
     if args.use_dask:
         logging.warning("Attempting to use dask client for SIC processing")

--- a/icenet/model/train.py
+++ b/icenet/model/train.py
@@ -28,7 +28,7 @@ from icenet.utils import setup_logging
 def train_model(
     run_name: object,
     dataset: object,
-    callback_objects: list = None,
+    callback_objects: list = [],
     checkpoint_monitor: str = 'val_rmse',
     checkpoint_mode: str = 'min',
     dataset_ratio: float = 1.0,


### PR DESCRIPTION
Fixes #181:
- When initialising a dataloder from a dataset, it now has the same `n_forecast_days` as the dataset by default (so now passing a `n_forecast_days` argument in the IceNetDataSet.get_data_loader() method)
  - I've also done this for the number of workers too as that is something that wasn't being recorded in the dataset config to recreate the dataloader
- Added `n_forecast_days` argument `to IceNetDataSet.get_data_loader()` to allow user to have a different `n_forecast_days` in the dataloader than that of the dataset
- Added `n_forecast_days` argument to `IceNetBaseDataLoader.generate_sample()` to allow user to specify a different `n_forecast_days` than what has been set when the dataloader was created.

There is also some other small fixes to other issues - these were needed to make the notebooks run properly I think.