### PR TITLE
Fixes #198: Linting fixes

### DIFF
--- a/icenet/data/processors/utils.py
+++ b/icenet/data/processors/utils.py
@@ -71,12 +71,12 @@ def sic_interpolate(da: object,
                 nan_neighbour_arr[-1, :] = False
 
             if np.sum(nan_neighbour_arr) == 1:
-                res = np.where(np.array(nan_neighbour_arr) == True)
+                res = np.where(np.array(nan_neighbour_arr) == True)  # noqa: E712
                 logging.warning("Not enough nans for interpolation, extending {}".format(res))
                 x_idx, y_idx = res[0][0], res[1][0]
                 nan_neighbour_arr[x_idx-1:x_idx+2, y_idx] = True
                 nan_neighbour_arr[x_idx, y_idx-1:y_idx+2] = True
-                logging.debug(np.where(np.array(nan_neighbour_arr) == True))
+                logging.debug(np.where(np.array(nan_neighbour_arr) == True))  # noqa: E712
 
             # Perform bilinear interpolation
             x_valid = xx[nan_neighbour_arr]

--- a/icenet/model/train.py
+++ b/icenet/model/train.py
@@ -3,11 +3,8 @@ import datetime as dt
 import json
 import logging
 import os
-import pkg_resources
 import random
 import time
-
-from pprint import pformat
 
 import numpy as np
 import pandas as pd

--- a/icenet/plotting/data.py
+++ b/icenet/plotting/data.py
@@ -14,7 +14,6 @@ from icenet.data.cli import date_arg
 from icenet.data.dataset import IceNetDataSet
 from icenet.utils import setup_logging
 
-import matplotlib as mpl
 import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -737,9 +737,9 @@ def standard_deviation_heatmap(metric: str,
     if metric in ["mae", "mse", "rmse"]:
         ylabel = f"SIC {metric.upper()} (%)"
     elif metric == "binacc":
-        ylabel = f"Binary accuracy (%)"
+        ylabel = "Binary accuracy (%)"
     elif metric == "sie":
-        ylabel = f"SIE error (km)"
+        ylabel = "SIE error (km)"
         
     # plot heatmap of standard deviation for IceNet
     fig, ax = plt.subplots(figsize=(12, 6))
@@ -903,9 +903,9 @@ def plot_metrics_leadtime_avg(metric: str,
     if metric in ["mae", "mse", "rmse"]:
         ylabel = f"SIC {metric.upper()} (%)"
     elif metric == "binacc":
-        ylabel = f"Binary accuracy (%)"
+        ylabel = "Binary accuracy (%)"
     elif metric == "sie":
-        ylabel = f"SIE error (km)"
+        ylabel = "SIE error (km)"
     
     if average_over == "all":
         # averaging metric over leadtime for all forecasts

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -6,6 +6,7 @@ import re
 
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import xarray as xr
 


### PR DESCRIPTION
Fixes linting issues in #198, opted to ignore `E721 Do not compare types, use 'isinstance()'`.

May revisit later, but `type()` currently used for standard built-in types.