### PR TITLE
Fixes #192: Issue running icenet_data_sic with 2020 date range

### DIFF
--- a/icenet/data/sic/osisaf.py
+++ b/icenet/data/sic/osisaf.py
@@ -322,7 +322,7 @@ class SICDownloader(Downloader):
 
         cache = {}
         osi430b_start = dt.date(2016, 1, 1)
-        osi430a_start = dt.date(2018, 11, 18)
+        osi430a_start = dt.date(2021, 1, 1)
 
         dt_arr = list(reversed(sorted(copy.copy(self._dates))))
 


### PR DESCRIPTION
Fixes #192 by correcting start date for OSI SAF 430a dataset download.