### PR TITLE
Fixes #201 tox environment set-up error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dask
 distributed
 eccodes
 ecmwf-api-client
-h5py==2.10.0
+h5py
 ibicus
 matplotlib
 motuclient


### PR DESCRIPTION
Fixes #201 by unpinning older h5py version with newer Python versions. Newer h5py version required on newer Python versions.

Need to review, if still causing conflicts with Issue #62 - which might be due to a specific local/conda hdf5 library.