### PR TITLE
Fixes #207: Make parallel read an optional arg

### DIFF
--- a/icenet/data/loaders/dask.py
+++ b/icenet/data/loaders/dask.py
@@ -223,7 +223,7 @@ class DaskMultiWorkerLoader(DaskBaseDataLoader):
                 np.average(exec_times)))
         self._write_dataset_config(counts)
 
-    def generate_sample(self, date: object, prediction: bool = False):
+    def generate_sample(self, date: object, prediction: bool = False, parallel=True):
         """
 
         :param date:
@@ -234,7 +234,7 @@ class DaskMultiWorkerLoader(DaskBaseDataLoader):
         ds_kwargs = dict(
             chunks=dict(time=1, yc=self._shape[0], xc=self._shape[1]),
             drop_variables=["month", "plev", "level", "realization"],
-            parallel=True,
+            parallel=parallel,
         )
         var_files = self.get_sample_files()
 
@@ -242,6 +242,7 @@ class DaskMultiWorkerLoader(DaskBaseDataLoader):
             v for k, v in var_files.items()
             if k not in self._meta_channels and not k.endswith("linear_trend")
         ], **ds_kwargs)
+
         var_ds = var_ds.transpose("yc", "xc", "time")
 
         trend_files = \


### PR DESCRIPTION
Allows serial reads into xarray dataset from netCDF files in `DaskMultiWorkerLoader` class when loading multiple files.

This allows PyTorch dataloader to use the existing `IceNetDataLoader` class to generate samples without causing intermitted & random file close errors (when `generate_samples()` is called with `parallel=False`).

Leave it as `True` by default for backwards compatibility.