### PR TITLE
Fixes #212: Updates tf install to use cuda

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ scitools-iris
 seaborn
 setuptools
 tensorboard
-tensorflow
+tensorflow[and-cuda]
 tensorflow-probability
 wheel
 xarray[io]


### PR DESCRIPTION
Fixes #212 on tensorflow install by updating requirements file.

Relates to icenet-ai/icenet-pipeline#28