### PR TITLE
Resolves #214: h5py dependency error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dask
 distributed
 eccodes
 ecmwf-api-client
-h5py
+h5py>2.10
 ibicus
 matplotlib
 motuclient


### PR DESCRIPTION
Resolves #214 where v0.2.6 and earlier can have dependency issue with numpy in Python 3.8 by enforcing h5py to be newer than the version pinned till v0.2.7.