### PR TITLE
Fixes #217: OSI-SAF SIC already downloaded dates not skipped

### DIFF
--- a/icenet/data/sic/osisaf.py
+++ b/icenet/data/sic/osisaf.py
@@ -411,7 +411,9 @@ class SICDownloader(Downloader):
 
         if len(extant_paths) > 0:
             extant_ds = xr.open_mfdataset(extant_paths)
-            exclude_dates = pd.to_datetime(extant_ds.time.values)
+            exclude_dates = [
+                pd.to_datetime(date).date() for date in extant_ds.time.values
+            ]
             logging.info("Excluding {} dates already existing from {} dates "
                          "requested.".format(len(exclude_dates), len(dt_arr)))
 


### PR DESCRIPTION
Fixes issue #217, where already downloaded dates are not skipped.

Now, correctly identifies the number of dates that will be skipped since already downloaded. Before, would always say dates would be excluded, but not actually be excluded in processing.

Have verified through dumps and diffs of the merged netCDF file.