### PR TITLE
Fixes #231 dask resource release

### DIFF
--- a/icenet/data/loaders/dask.py
+++ b/icenet/data/loaders/dask.py
@@ -66,15 +66,14 @@ class DaskBaseDataLoader(IceNetBaseDataLoader):
                 "distributed.comm.timeouts.connect": self._timeout,
                 "distributed.comm.timeouts.tcp": self._timeout,
         }):
-            cluster = LocalCluster(
+            with LocalCluster(
                 dashboard_address=dashboard,
                 n_workers=self.workers,
                 threads_per_worker=1,
                 scheduler_port=0,
-            )
-            logging.info("Dashboard at {}".format(dashboard))
+            ) as cluster, Client(cluster) as client:
+                logging.info("Dashboard at {}".format(dashboard))
 
-            with Client(cluster) as client:
                 logging.info("Using dask client {}".format(client))
                 self.client_generate(client,
                                      dates_override=self.dates_override,


### PR DESCRIPTION
Fixes #231 

Initialise `LocalCluster` using context manager so resources are released once compute is complete.

Else, currently, the workers are left running. Finding it to be a limiting issue with low memory systems.