### PR TITLE
Fixes #197 Drop python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
         "Natural Language :: English",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         ],
     entry_points={
         "console_scripts": [
@@ -97,7 +97,7 @@ setup(
             "icenet.results.threshold:threshold_main"
         ],
         },
-    python_requires='>=3.7, <4',
+    python_requires='>=3.8, <4',
     install_requires=get_content("requirements.txt"),
     include_package_data=True,
     extras_require={


### PR DESCRIPTION
Fixes #197, removes 3.7 from `setup.py`.