### PR TITLE
Fixes #238: Constrain Tensorflow version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ scitools-iris
 seaborn
 setuptools
 tensorboard
-tensorflow
+tensorflow<2.16
 tensorflow-probability
 wheel
 xarray[io]<2023.2.0


### PR DESCRIPTION
Resolves #238 

Constrain Tensorflow version so Keras 2 is installed easily alongside it, since Keras>=3 requires saving models to `.keras` files instead of `.h5`

See corresponding issue for more details.