### PR TITLE
Resolves #222: Mention installation of eccodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,16 @@ this library.
 
 We're still working on clear dependency management using pip, Tensorflow is best through pip but obviously you need NVIDIA dependencies for GPU based training. If you're having trouble with system dependencies some advice about environment setup is given by the examples [under the pipeline repository][1].
 
-Please note that icenet has an optional dependency on eccodes which requires a system library and a python wrapper. The system library can be installed via:
+Please note that icenet has an optional dependency on eccodes which requires a system library and a python wrapper. The system library can be installed via conda.
+
+By default, Tensorflow will be built for CPU only when icenet is installed via pip. So, optionally, Tensorflow can be installed with CUDA support (recommended).
 
 ```bash
 conda install -c conda-forge eccodes
-```
 
-followed by:
-
-```bash
 pip install icenet
-```
 
-This will also install tensorflow with CPU support. To install newer versions of tensorflow (tensorflow>=2.14) with CUDA deps directly via pip:
-
-```bash
+# To install newer versions of tensorflow (tensorflow>=2.14) with CUDA deps directly via pip:
 pip install tensorflow[and-cuda]<2.16
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,9 +26,25 @@ this library.
 
 We're still working on clear dependency management using pip, Tensorflow is best through pip but obviously you need NVIDIA dependencies for GPU based training. If you're having trouble with system dependencies some advice about environment setup is given by the examples [under the pipeline repository][1].
 
+Please note that icenet has an optional dependency on eccodes which requires a system library and a python wrapper. The system library can be installed via:
+
+```bash
+conda install -c conda-forge eccodes
 ```
+
+followed by:
+
+```bash
 pip install icenet
 ```
+
+This will also install tensorflow with CPU support. To install newer versions of tensorflow (tensorflow>=2.14) with CUDA deps directly via pip:
+
+```bash
+pip install tensorflow[and-cuda]<2.16
+```
+
+Please consult the [tensorflow docs](https://www.tensorflow.org/install/pip) for up-to-date info.
 
 ### Development installation
 


### PR DESCRIPTION
Resolves #222 

Mention installation requirement of system eccodes library in addition to the python wrapper.

Also, mentions the `add-cuda` extra available when installing newer versions of Tensorflow that will install CUDA packages via pip for Nvidia GPU support.

```bash
pip install tensorflow[and-cuda]<2.16
```