### PR TITLE
Fix torch logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ ENV/
 # mypy
 .mypy_cache/
 
+# VIM swap files
+*.swp
+
 # IDE settings
 .vscode/
 .idea/

--- a/icenet/data/dataset.py
+++ b/icenet/data/dataset.py
@@ -19,9 +19,9 @@ pytorch_available = False
 try:
     from torch.utils.data import Dataset
 except ModuleNotFoundError:
-    logger.warning("PyTorch not found - not required if not using PyTorch")
+    print("PyTorch not found - not required if not using PyTorch")
 except ImportError:
-    logger.warning("PyTorch import failed - not required if not using PyTorch")
+    print("PyTorch import failed - not required if not using PyTorch")
 
 """
 

--- a/icenet/data/dataset.py
+++ b/icenet/data/dataset.py
@@ -12,6 +12,17 @@ from icenet.data.loader import IceNetDataLoaderFactory
 from icenet.data.producers import DataCollection
 from icenet.utils import setup_logging
 
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.WARNING)
+
+pytorch_available = False
+try:
+    from torch.utils.data import Dataset
+except ModuleNotFoundError:
+    logger.warning("PyTorch not found - not required if not using PyTorch")
+except ImportError:
+    logger.warning("PyTorch import failed - not required if not using PyTorch")
+
 """
 
 
@@ -320,8 +331,7 @@ class MergedIceNetDataSet(SplittingMixin, DataCollection):
         return self._config["counts"]
 
 
-try:
-    from torch.utils.data import Dataset
+if pytorch_available:
     class IceNetDataSetPyTorch(IceNetDataSet, Dataset):
         """Initialises and configures a PyTorch dataset.
         """
@@ -369,11 +379,6 @@ try:
         @property
         def dates(self):
             return self._dates
-except ModuleNotFoundError:
-    logging.warning("PyTorch module not found - not mandatory if not using PyTorch")
-except ImportError:
-    logging.warning("PyTorch import failed - not mandatory if not using PyTorch")
-
 
 @setup_logging
 def get_args() -> object:


### PR DESCRIPTION
Potentially fix the root logger being set to warning - where the first logging call (warning that PyTorch was not installed/loadable) would set the loglevel for the root logger and affect every log call.