### PR TITLE
Fixes #235 defensive generate workers

### DIFF
--- a/icenet/data/dataset.py
+++ b/icenet/data/dataset.py
@@ -88,7 +88,7 @@ class IceNetDataSet(SplittingMixin, DataCollection):
         self._counts = self._config["counts"]
         self._dtype = getattr(np, self._config["dtype"])
         self._loader_config = self._config["loader_config"]
-        self._generate_workers = self._config["generate_workers"]
+        self._generate_workers = self._config.get("generate_workers", 4)
         self._n_forecast_days = self._config["n_forecast_days"]
         self._num_channels = self._config["num_channels"]
         self._shape = tuple(self._config["shape"])
@@ -148,7 +148,7 @@ class IceNetDataSet(SplittingMixin, DataCollection):
         if n_forecast_days is None:
             n_forecast_days = self._config["n_forecast_days"]
         if generate_workers is None:
-            generate_workers = self._config["generate_workers"]
+            generate_workers = self._config.get("generate_workers", 4)
         loader = IceNetDataLoaderFactory().create_data_loader(
             "dask",  # This will load the `DaskMultiWorkerLoader` class.
             self.loader_config,


### PR DESCRIPTION
Resolves #235 

Uses `.get` to set defaults for `generate_workers` to cover previous versions where this was not specfied in the `dataset_config.{name}.config` file.