### PR TITLE
Resolves #270 ORAS5Downloader downloader update

### DIFF
--- a/icenet/exceptions.py
+++ b/icenet/exceptions.py
@@ -1,0 +1,7 @@
+
+class CredentialsNotFoundError(Exception):
+    """ Covers scenarios where a credential file has not been found"""
+    def __init(self, message = "Credentials not found"):
+        self.message = message
+        super().__init__(message)
+


### PR DESCRIPTION
Fixes #270

This replaces MOTU client usage for downloading ORAS5 ocean data which is no longer in service as of [March 2024](https://marine.copernicus.eu/user-corner/user-notification-service/transition-marine-data-store).

Will not close the relating issue since this uses CLI approach for simpler tie-in with previous approach.

Would recommend moving to Copernicus marine toolbox Python API (very low prio), but easy transition.

metadata caching is disabled to avoid having to change the default caching directory, and prevent `LockException` error:

https://help.marine.copernicus.eu/en/articles/8632322-copernicus-marine-toolbox-troubleshoots#h_974e43dc00