### PR TITLE
Fixes #279 and #100 plotting updates

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,9 +3,6 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - eccodes
-  - ffmpeg
-  - netcdf4<1.6.1
   - pip
   - python=3.11
   - pip:

--- a/icenet/data/process.py
+++ b/icenet/data/process.py
@@ -487,6 +487,7 @@ class IceNetPreProcessor(Processor):
 
         scale_path = os.path.join(proc_dir, "{}".format(var_name))
 
+        print("Scale path:", scale_path)
         if os.path.exists(scale_path):
             logging.debug(
                 "Loading norm-scaling min-max from {}".format(scale_path))

--- a/icenet/data/process.py
+++ b/icenet/data/process.py
@@ -487,7 +487,6 @@ class IceNetPreProcessor(Processor):
 
         scale_path = os.path.join(proc_dir, "{}".format(var_name))
 
-        print("Scale path:", scale_path)
         if os.path.exists(scale_path):
             logging.debug(
                 "Loading norm-scaling min-max from {}".format(scale_path))

--- a/icenet/plotting/__init__.py
+++ b/icenet/plotting/__init__.py
@@ -1,0 +1,3 @@
+from icenet.plotting.utils import set_ffmpeg_path
+
+set_ffmpeg_path()

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -33,7 +33,7 @@ from icenet.plotting.utils import (calculate_extents, filter_ds_by_obs,
                                    get_seas_forecast_init_dates,
                                    geographic_box, show_img,
                                    get_plot_axes, set_plot_geoaxes, process_probes,
-                                   process_subregion, get_custom_cmap,
+                                   process_region, get_custom_cmap,
                                    get_crs)
 from icenet.plotting.video import xarray_to_video
 
@@ -600,13 +600,13 @@ def compute_metrics_leadtime_avg(metric: str,
             seas = None
 
         if region is not None:
-            seas, fc, obs, masks = process_subregion(region,
+            seas, fc, obs, masks = process_region(region,
                                         [seas, fc, obs, masks],
                                         pole,
                                         region_definition="pixel",
                                         )
         elif region_geographic is not None:
-            seas, fc, obs, masks = process_subregion(region_geographic,
+            seas, fc, obs, masks = process_region(region_geographic,
                                         [seas, fc, obs, masks],
                                         pole,
                                         src_da=obs,
@@ -1517,13 +1517,13 @@ def binary_accuracy():
         seas = None
 
     if args.region is not None:
-        seas, fc, obs, masks = process_subregion(args.region,
+        seas, fc, obs, masks = process_region(args.region,
                                     [seas, fc, obs, masks],
                                     pole,
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
-        seas, fc, obs, masks = process_subregion(args.region_geographic,
+        seas, fc, obs, masks = process_region(args.region_geographic,
                                     [seas, fc, obs, masks],
                                     pole,
                                     src_da=obs,
@@ -1573,13 +1573,13 @@ def sie_error():
         seas = None
 
     if args.region is not None:
-        seas, fc, obs, masks = process_subregion(args.region,
+        seas, fc, obs, masks = process_region(args.region,
                                     [seas, fc, obs, masks],
                                     pole,
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
-        seas, fc, obs, masks = process_subregion(args.region_geographic,
+        seas, fc, obs, masks = process_region(args.region_geographic,
                                     [seas, fc, obs, masks],
                                     pole,
                                     src_da=obs,
@@ -1718,7 +1718,7 @@ def plot_forecast():
     if not args.clip_region:
         region_args = None
 
-    fc = process_subregion(region_args,
+    fc = process_region(region_args,
                             [fc],
                             pole,
                             region_definition=region_definition,
@@ -1917,13 +1917,13 @@ def metric_plots():
         seas = None
 
     if args.region is not None:
-        seas, fc, obs, masks = process_subregion(args.region,
+        seas, fc, obs, masks = process_region(args.region,
                                     [seas, fc, obs, masks],
                                     pole,
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
-        seas, fc, obs, masks = process_subregion(args.region_geographic,
+        seas, fc, obs, masks = process_region(args.region_geographic,
                                     [seas, fc, obs, masks],
                                     pole,
                                     src_da=obs,
@@ -2018,13 +2018,13 @@ def sic_error():
     fc = filter_ds_by_obs(fc, obs, args.forecast_date)
 
     if args.region is not None:
-        fc, obs, masks = process_subregion(args.region,
+        fc, obs, masks = process_region(args.region,
                                     [fc, obs, masks],
                                     pole,
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
-        fc, obs, masks = process_subregion(args.region_geographic,
+        fc, obs, masks = process_region(args.region_geographic,
                                     [fc, obs, masks],
                                     pole,
                                     src_da=obs,

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -32,7 +32,7 @@ from icenet.plotting.utils import (calculate_extents, filter_ds_by_obs,
                                    get_obs_da, get_seas_forecast_da,
                                    get_seas_forecast_init_dates,
                                    geographic_box, show_img,
-                                   get_plot_axes, process_probes,
+                                   get_plot_axes, set_plot_geoaxes, process_probes,
                                    process_regions, get_custom_cmap,
                                    get_crs)
 from icenet.plotting.video import xarray_to_video
@@ -1783,29 +1783,33 @@ def plot_forecast():
                         **anim_args)
     else:
         fig, ax = get_plot_axes(**bound_args,
-                        geoaxes=True,
-                        target_crs=target_crs,
-                        transform_crs=data_crs_geo,
-                        coastlines=coastlines,
-                        gridlines=args.gridlines,
-                        )
+                                geoaxes=True,
+                                target_crs=target_crs
+                                )
+        ax = set_plot_geoaxes(ax,
+                              coastlines=coastlines,
+                              gridlines=args.gridlines,
+                              transform_crs=data_crs_geo,
+                              )
+
         for i, leadtime in enumerate(leadtimes):
             pred_da = fc.sel(leadtime=leadtime).isel(time=0)
 
             im = pred_da.plot.pcolormesh("xc",
-                                            "yc",
-                                            ax=ax,
-                                            transform=target_crs,
-                                            vmin=0,
-                                            vmax=vmax,
-                                            add_colorbar=False,
-                                            cmap=custom_cmap,
-                                            # shading="gouraud",
-                                            # rasterized=True,
-                                            )
+                                         "yc",
+                                         ax=ax,
+                                         transform=target_crs,
+                                         vmin=0,
+                                         vmax=vmax,
+                                         add_colorbar=False,
+                                         cmap=custom_cmap,
+                                         # shading="gouraud",
+                                         # rasterized=True,
+                                         )
 
             if args.region_geographic:
                 # Special case, when using geographic (lon/lat) region clipping
+                # Highlights sub-region being plotted in a reference plot of the globe
                 stored_extent = ax.get_extent()
 
                 # Output a reference image showing cropped region

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1776,7 +1776,6 @@ def plot_forecast():
                         gridlines=args.gridlines,
                         target_crs=target_crs,
                         transform_crs=transform_crs,
-                        # ax_init=plt.axes(projection=ccrs.PlateCarree()) if reproject else None
                         north=bound_args["north"],
                         south=bound_args["south"],
                         **anim_args)
@@ -1787,12 +1786,6 @@ def plot_forecast():
             # Standard output plot or using pixel region clipping
             if args.region_lat_lon is None:
                 print("Standard plot")
-                # if args.crs and args.region is not None:
-                #     lon, lat = fc.lon.values, fc.lat.values
-                #     extent = [lon.min(), lon.max(), lat.min(), lat.max()]
-                #     # ax.set_extent(extent, crs=target_crs)
-                # else:
-                #     extent = None
                 im = pred_da.plot.pcolormesh("xc",
                                              "yc",
                                              ax=ax,
@@ -1802,18 +1795,6 @@ def plot_forecast():
                                              add_colorbar=False,
                                              cmap=custom_cmap,
                                              )
-                # im = pred_da.plot.imshow(ax=ax, transform=target_crs,
-                #                              vmin=0,
-                #                              vmax=vmax,
-                #                              add_colorbar=False,
-                #                              cmap=custom_cmap,
-                #                              )
-                # im = pred_da.plot.pcolormesh("lon",
-                #                             "lat",
-                #                             ax=ax,
-                #                             transform=target_crs,
-                #                             add_colorbar=False,
-                #                             )
             # Using lat/lon region clipping
             else:
                 # cmap.set_bad("dimgrey", alpha=0)
@@ -1823,20 +1804,6 @@ def plot_forecast():
 
                 lon, lat = fc.lon.values, fc.lat.values
 
-                # im = ax.pcolormesh(pred_da.xc.values, pred_da.yc.values, data, transform=data_crs, vmin=0, vmax=vmax, cmap=custom_cmap)
-                # im = pred_da.plot.imshow(ax=ax, transform=transform_crs,
-                #                              vmin=0,
-                #                              vmax=vmax,
-                #                              add_colorbar=False,
-                #                              cmap=custom_cmap,
-                #                              )
-                # im = pred_da.plot.pcolormesh("lon",
-                #                             "lat",
-                #                             ax=ax,
-                #                             transform=transform_crs,
-                #                             add_colorbar=False,
-                #                             cmap=custom_cmap,
-                #                             )
                 im = pred_da.plot.pcolormesh("xc",
                                              "yc",
                                              ax=ax,

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1766,8 +1766,7 @@ def plot_forecast():
         xarray_to_video(pred_da,
                         fps=1,
                         cmap=cmap,
-                        imshow_kwargs=dict(vmin=0., vmax=vmax)
-                        if not args.stddev else None,
+                        imshow_kwargs={},
                         video_path=output_filename,
                         reproject=reproject,
                         extent=extent,
@@ -1778,6 +1777,7 @@ def plot_forecast():
                         transform_crs=transform_crs,
                         north=bound_args["north"],
                         south=bound_args["south"],
+                        clim=(0, vmax),
                         **anim_args)
     else:
         for i, leadtime in enumerate(leadtimes):

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1653,7 +1653,13 @@ def plot_forecast():
         os.path.splitext(os.path.basename(args.forecast_file))[0],
         args.forecast_date)
 
-    cmap_name = "BuPu_r" if args.stddev else "Blues_r"
+    if args.stddev:
+        cmap_name = "BuPu_r"
+        colorbar_label = "Sea-ice concentration fraction (standard deviation)"
+    else:
+        cmap_name = "Blues_r"
+        colorbar_label = "Sea-ice concentration fraction"
+
     if args.cmap_name is not None:
         cmap_name = args.cmap_name
 
@@ -1736,8 +1742,6 @@ def plot_forecast():
                     gridlines=args.gridlines,
                     )
 
-    plt.tight_layout(pad=4.0)
-
     custom_cmap = get_custom_cmap(cmap)
 
     if args.format == "mp4":
@@ -1778,6 +1782,7 @@ def plot_forecast():
                         north=bound_args["north"],
                         south=bound_args["south"],
                         clim=(0, vmax),
+                        colorbar_label=colorbar_label,
                         **anim_args)
     else:
         for i, leadtime in enumerate(leadtimes):
@@ -1841,13 +1846,18 @@ def plot_forecast():
 
             divider = make_axes_locatable(ax)
             # Pass axes_class to set correct colourbar height with cartopy
-            cax = divider.append_axes("right", size="5%", pad=0.1, axes_class=plt.Axes)
-            plt.colorbar(im, ax=ax, cax=cax)
+            cax = divider.append_axes("right", size="5%", pad=0.05, axes_class=plt.Axes)
+            cbar = plt.colorbar(im, ax=ax, cax=cax)
 
             plot_date = args.forecast_date + dt.timedelta(leadtime)
             ax.set_title("{:04d}/{:02d}/{:02d}".format(plot_date.year,
                                                        plot_date.month,
-                                                       plot_date.day))
+                                                       plot_date.day),
+                                                       fontsize="large",
+                                                       )
+            if colorbar_label:
+                cbar.set_label(colorbar_label)
+            plt.subplots_adjust(right=0.5)
             output_filename = os.path.join(
                 output_path, "{}.{}.{}{}".format(
                     forecast_name,

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1672,13 +1672,6 @@ def plot_forecast():
         target_crs = data_crs
     transform_crs = ccrs.PlateCarree()
 
-    ## Clip the actual data to the requested region.
-    ## This can cause empty region at the borders if used with different CRS projections
-    ## due to re-projection.
-    if args.crs:
-        logging.warning(f"Using {args.crs} for plot reprojection, this can cause " \
-            "empty regions along the outer edges due to re-projection.")
-
     region_args = None
     method = "pixel"
     if args.region is not None:
@@ -1687,8 +1680,16 @@ def plot_forecast():
         region_args = args.region_lat_lon
         method = "lat_lon"
 
+
+    ## Clip the actual data to the requested region.
+    ## This can cause empty region at the borders if used with different CRS projections
+    ## due to re-projection.
+    if args.crs and args.region_lat_lon:
+        logging.warning(f"Using {args.crs} for plot reprojection, this can cause " \
+            "empty regions along the outer edges due to re-projection.")
+
     # Reproject, and process regions if necessary
-    # TODO: Split thsi function to separate `reproject` and `process_regions`
+    # TODO: Split this function to separate `reproject` and `process_regions`
     fc = process_regions(region_args, [fc], method=method, proj=target_crs, pole=pole, no_clip_region=args.no_clip_region)[0]
 
     vmax = 1.

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1136,8 +1136,11 @@ def sic_error_video(fc_da: object, obs_da: object, land_mask: object,
     """
 
     diff = fc_da - obs_da
-    fig, maps = plt.subplots(nrows=1, ncols=3, figsize=(16, 6), layout="tight")
+    fig, maps = plt.subplots(nrows=1, ncols=3, figsize=(16, 6))
     fig.set_dpi(150)
+    # Call tight layout once instead of in subplots - else can keep
+    # changing layout each frame
+    fig.tight_layout(pad=2)
 
     leadtime = 0
     fc_plot = fc_da.isel(time=leadtime).to_numpy()
@@ -1177,17 +1180,28 @@ def sic_error_video(fc_da: object, obs_da: object, land_mask: object,
     p1 = maps[1].get_position().get_points().flatten()
     p2 = maps[2].get_position().get_points().flatten()
 
-    ax_cbar = fig.add_axes([p0[0] - 0.05, 0.04, p1[2] - p0[0], 0.02])
-    plt.colorbar(im1, orientation='horizontal', cax=ax_cbar)
+    divider1 = make_axes_locatable(maps[0])
+    ax_cbar1 = divider1.append_axes("bottom", size="5%", pad=0.1)
+    cbar1 = fig.colorbar(im1, orientation='horizontal', cax=ax_cbar1)
+    cbar1.set_label("Sea-ice concentration fraction")
 
-    ax_cbar1 = fig.add_axes([p2[0] + 0.05, 0.04, p2[2] - p2[0], 0.02])
-    plt.colorbar(im3, orientation='horizontal', cax=ax_cbar1)
+    divider2 = make_axes_locatable(maps[1])
+    ax_cbar2 = divider2.append_axes("bottom", size="5%", pad=0.1)
+    cbar2 = fig.colorbar(im2, orientation='horizontal', cax=ax_cbar2)
+    cbar2.set_label("Sea-ice concentration fraction")
+
+    divider3 = make_axes_locatable(maps[2])
+    ax_cbar3 = divider3.append_axes("bottom", size="5%", pad=0.1)
+    cbar3 = fig.colorbar(im3, orientation='horizontal', cax=ax_cbar3)
+    cbar3.set_label("Difference")
 
     for m_ax in maps[0:3]:
         m_ax.tick_params(
             labelbottom=False,
             labelleft=False,
         )
+        m_ax.set_xticks([])
+        m_ax.set_yticks([])
         m_ax.contourf(land_mask,
                       levels=[.5, 1],
                       colors=[mpl.cm.gray(180)],

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1809,6 +1809,8 @@ def plot_forecast():
                                             vmax=vmax,
                                             add_colorbar=False,
                                             cmap=custom_cmap,
+                                            # shading="gouraud",
+                                            # rasterized=True,
                                             )
 
             if args.region_geographic:

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1762,7 +1762,7 @@ def plot_forecast():
         # ax = plt.axes(projection=target_crs)
 
         if not args.no_coastlines:
-            ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=100)
+            # ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=100)
             ax.coastlines(resolution="10m", zorder=100)
             # ax.add_feature(cfeature.GSHHSFeature(scale="full"))
             # ax.add_feature(cfeature.COASTLINE)
@@ -1785,22 +1785,44 @@ def plot_forecast():
 
             # Standard output plot or using pixel region clipping
             if args.region_lat_lon is None:
-                if args.crs and args.region is not None:
-                    lon, lat = fc.lon.values, fc.lat.values
-                    extent = [lon.min(), lon.max(), lat.min(), lat.max()]
-                    # ax.set_extent(extent, crs=target_crs)
-                else:
-                    extent = None
-                # im = pred_da.plot.pcolormesh("x",
-                #                              "y",
-                #                              ax=ax,
-                #                              transform=target_crs,
+                # if args.crs and args.region is not None:
+                #     lon, lat = fc.lon.values, fc.lat.values
+                #     extent = [lon.min(), lon.max(), lat.min(), lat.max()]
+                #     # ax.set_extent(extent, crs=target_crs)
+                # else:
+                #     extent = None
+                im = pred_da.plot.pcolormesh("xc",
+                                             "yc",
+                                             ax=ax,
+                                             transform=target_crs,
+                                             vmin=0,
+                                             vmax=vmax,
+                                             add_colorbar=False,
+                                             cmap=custom_cmap,
+                                             )
+                # im = pred_da.plot.imshow(ax=ax, transform=target_crs,
                 #                              vmin=0,
                 #                              vmax=vmax,
                 #                              add_colorbar=False,
                 #                              cmap=custom_cmap,
                 #                              )
-                # im = pred_da.plot.imshow(ax=ax, transform=target_crs,
+                # im = pred_da.plot.pcolormesh("lon",
+                #                             "lat",
+                #                             ax=ax,
+                #                             transform=target_crs,
+                #                             add_colorbar=False,
+                #                             )
+            # Using lat/lon region clipping
+            else:
+                # cmap.set_bad("dimgrey", alpha=0)
+                # Hack since cartopy needs transparency for nan regions to wraparound
+                # correctly with pcolormesh.
+                data = np.where(np.isnan(pred_da), -9999, pred_da)
+
+                lon, lat = fc.lon.values, fc.lat.values
+
+                # im = ax.pcolormesh(pred_da.x.values, pred_da.y.values, data, transform=target_crs, vmin=0, vmax=vmax, cmap=custom_cmap)
+                # im = pred_da.plot.imshow(ax=ax, transform=transform_crs,
                 #                              vmin=0,
                 #                              vmax=vmax,
                 #                              add_colorbar=False,
@@ -1812,22 +1834,6 @@ def plot_forecast():
                                             transform=transform_crs,
                                             add_colorbar=False,
                                             )
-            # Using lat/lon region clipping
-            else:
-                # cmap.set_bad("dimgrey", alpha=0)
-                # Hack since cartopy needs transparency for nan regions to wraparound
-                # correctly with pcolormesh.
-                data = np.where(np.isnan(pred_da), -9999, pred_da)
-
-                lon, lat = fc.lon.values, fc.lat.values
-
-                # im = ax.pcolormesh(x, y, data, transform=target_crs, vmin=0, vmax=vmax, cmap=custom_cmap)
-                im = pred_da.plot.imshow(ax=ax, transform=target_crs,
-                                             vmin=0,
-                                             vmax=vmax,
-                                             add_colorbar=False,
-                                             cmap=custom_cmap,
-                                             )
                 stored_extent = ax.get_extent()
 
                 # Output a reference image showing cropped region
@@ -1849,7 +1855,7 @@ def plot_forecast():
 
                 extent = bound_args["x1"], bound_args["x2"], bound_args["y1"], bound_args["y2"]
                 print("Extent:", extent)
-                ax.set_extent(extent, crs=transform_crs)
+                # ax.set_extent(extent, crs=transform_crs)
 
             divider = make_axes_locatable(ax)
             # Pass axes_class to set correct colourbar height with cartopy

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -527,9 +527,10 @@ def compute_metrics_leadtime_avg(metric: str,
                                  data_path: str,
                                  bias_correct: bool = False,
                                  region: tuple = None,
+                                 region_lat_lon: tuple = None,
                                  **kwargs) -> object:
     """
-    Given forecast file, for each initialisation date in the xarrray.DataArray
+    Given forecast file, for each initialisation date in the xarray.DataArray
     we compute the metric for each leadtime and store the results
     in a pandas dataframe with columns 'date' (specifying the initialisation date),
     'leadtime' and the metric name. This pandas dataframe can then be used
@@ -548,7 +549,8 @@ def compute_metrics_leadtime_avg(metric: str,
     :param bias_correct: bool to indicate whether or not to
                          perform a bias correction on SEAS forecast,
                          by default False. Ignored if ecmwf=False
-    :param region: region to zoom in to
+    :param region: region to zoom in to defined by pixel coordinates
+    :param region_lat_lon: region to zoom in to defined by lat/lon coordinates
     :param kwargs: any keyword arguments that are required for the computation
                    of the metric, e.g. 'threshold' for SIE error and binary accuracy
                    metrics, or 'grid_area_size' for SIE error metric
@@ -595,7 +597,16 @@ def compute_metrics_leadtime_avg(metric: str,
 
         if region is not None:
             seas, fc, obs, masks = process_regions(region,
-                                                   [seas, fc, obs, masks])
+                                        [seas, fc, obs, masks],
+                                        method="pixel"
+                                        )
+        elif region_lat_lon is not None:
+            raise NotImplementedError("Computing this metric with lat/lon region "
+                                    "bounds has not been implemented yet.")
+            seas, fc, obs, masks = process_regions(region_lat_lon,
+                                        [seas, fc, obs, masks],
+                                        method="lat_lon"
+                                        )
 
         # compute metrics
         fc_metrics_list.append(
@@ -823,6 +834,7 @@ def plot_metrics_leadtime_avg(metric: str,
                               target_date_avg: bool = False,
                               bias_correct: bool = False,
                               region: tuple = None,
+                              region_lat_lon: tuple = None,
                               **kwargs) -> object:
     """
     Plots leadtime averaged metrics either using all the forecasts
@@ -853,7 +865,8 @@ def plot_metrics_leadtime_avg(metric: str,
     :param bias_correct: bool to indicate whether or not to
                          perform a bias correction on SEAS forecast,
                          by default False. Ignored if ecmwf=False
-    :param region: region to zoom in to
+    :param region: region to zoom in to defined by pixel coordinates
+    :param region_lat_lon: region to zoom in to defined by lat/lon coordinates
     :param kwargs: any keyword arguments that are required for the computation
                    of the metric, e.g. 'threshold' for SIE error and binary accuracy
                    metrics, or 'grid_area_size' for SIE error metric
@@ -1498,9 +1511,19 @@ def binary_accuracy():
     else:
         seas = None
 
-    if args.region:
+    if args.region is not None:
         seas, fc, obs, masks = process_regions(args.region,
-                                               [seas, fc, obs, masks])
+                                    [seas, fc, obs, masks],
+                                    method="pixel"
+                                    )
+    elif args.region_lat_lon is not None:
+        raise NotImplementedError("Computing this metric with lat/lon region "
+                                "bounds has not been implemented yet.")
+        seas, fc, obs, masks = process_regions(args.region_lat_lon,
+                                    [seas, fc, obs, masks],
+                                    method="lat_lon"
+                                    )
+
 
     plot_binary_accuracy(masks=masks,
                          fc_da=fc,
@@ -1541,9 +1564,18 @@ def sie_error():
     else:
         seas = None
 
-    if args.region:
+    if args.region is not None:
         seas, fc, obs, masks = process_regions(args.region,
-                                               [seas, fc, obs, masks])
+                                    [seas, fc, obs, masks],
+                                    method="pixel"
+                                    )
+    elif args.region_lat_lon is not None:
+        raise NotImplementedError("Computing this metric with lat/lon region "
+                                "bounds has not been implemented yet.")
+        seas, fc, obs, masks = process_regions(args.region_lat_lon,
+                                    [seas, fc, obs, masks],
+                                    method="lat_lon"
+                                    )
 
     plot_sea_ice_extent_error(masks=masks,
                               fc_da=fc,
@@ -1723,7 +1755,7 @@ def plot_forecast():
             # gl.xlocator = mticker.FixedLocator([bound_args["x1"], bound_args["x2"]])
             # gl.ylocator = mticker.FixedLocator([bound_args["y1"], bound_args["y2"]])
 
-        plt.tight_layout(pad=3.0)
+        plt.tight_layout(pad=4.0)
 
         custom_cmap = get_custom_cmap(cmap)
 
@@ -1852,9 +1884,18 @@ def metric_plots():
     else:
         seas = None
 
-    if args.region:
+    if args.region is not None:
         seas, fc, obs, masks = process_regions(args.region,
-                                               [seas, fc, obs, masks])
+                                    [seas, fc, obs, masks],
+                                    method="pixel"
+                                    )
+    elif args.region_lat_lon is not None:
+        raise NotImplementedError("Computing this metric with lat/lon region "
+                                "bounds has not been implemented yet.")
+        seas, fc, obs, masks = process_regions(args.region_lat_lon,
+                                    [seas, fc, obs, masks],
+                                    method="lat_lon"
+                                    )
 
     plot_metrics(metrics=metrics,
                  masks=masks,
@@ -1940,8 +1981,18 @@ def sic_error():
         timedelta(days=int(fc.leadtime.max())))
     fc = filter_ds_by_obs(fc, obs, args.forecast_date)
 
-    if args.region:
-        fc, obs, masks = process_regions(args.region, [fc, obs, masks])
+    if args.region is not None:
+        fc, obs, masks = process_regions(args.region,
+                                    [fc, obs, masks],
+                                    method="pixel"
+                                    )
+    elif args.region_lat_lon is not None:
+        raise NotImplementedError("Computing this metric with lat/lon region "
+                                "bounds has not been implemented yet.")
+        fc, obs, masks = process_regions(args.region_lat_lon,
+                                    [fc, obs, masks],
+                                    method="lat_lon"
+                                    )
 
     sic_error_video(fc_da=fc,
                     obs_da=obs,

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1816,7 +1816,7 @@ def plot_forecast():
                 # Highlights sub-region being plotted in a reference plot of the globe
                 stored_extent = ax.get_extent()
 
-                # Output a reference image showing cropped region
+                # Output a reference image showing bounds of clipped region
                 if i == 0:
                     box_lon, box_lat = geographic_box((bound_args["x1"], bound_args["x2"]), (bound_args["y1"], bound_args["y2"]), segments=10)
 

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1770,10 +1770,11 @@ def plot_forecast():
 
         if not args.no_coastlines:
             ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=1)
-            ax.coastlines(resolution="10m", zorder=100)
-            # ax.add_feature(cfeature.GSHHSFeature(scale="full"))
-            # ax.add_feature(cfeature.COASTLINE)
-        # ax.set_global()
+            if args.region or args.region_lat_lon:
+                # Higher resolution coastlines when a region is specified
+                ax.add_feature(cfeature.GSHHSFeature(scale="high", levels=[1]), zorder=100)
+            else:
+                ax.coastlines(resolution="10m", zorder=100)
 
         if args.gridlines:
             gl = ax.gridlines(crs=transform_crs, draw_labels=True)

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1703,14 +1703,10 @@ def plot_forecast():
                                     y1=args.region_geographic[1],
                                     y2=args.region_geographic[3])
 
-    # Reproject, and clip the actual data to the requested region if necessary
-    # TODO: Split this function to separate `reproject` and `process_subregion`
+    # Clip the actual data to the requested region if necessary
     fc = process_subregion(region_args,
                             [fc],
                             region_definition=region_definition,
-                            target_crs=target_crs,
-                            pole=pole,
-                            clip_geographic_region=not args.no_clip_region
                         )[0]
 
     vmax = 1.
@@ -1795,10 +1791,10 @@ def plot_forecast():
         for i, leadtime in enumerate(leadtimes):
             pred_da = fc.sel(leadtime=leadtime).isel(time=0)
 
-            im = pred_da.plot.pcolormesh("xc",
-                                         "yc",
+            im = pred_da.plot.pcolormesh("lon",
+                                         "lat",
                                          ax=ax,
-                                         transform=target_crs,
+                                         transform=data_crs_geo,
                                          vmin=0,
                                          vmax=vmax,
                                          add_colorbar=False,

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1715,10 +1715,26 @@ def plot_forecast():
                             y1=args.region_lat_lon[0],
                             y2=args.region_lat_lon[2])
 
+    coastlines = "default"
     if args.region is not None or args.region_lat_lon is not None:
         extent = (bound_args["x1"], bound_args["x2"], bound_args["y1"], bound_args["y2"])
+        coastlines = "gshhs"
     else:
         extent = None
+
+    if args.no_coastlines:
+        coastlines = None
+
+    ax = get_plot_axes(**bound_args,
+                    geoaxes=True,
+                    target_crs=target_crs,
+                    coastlines=coastlines,
+                    gridlines=args.gridlines,
+                    )
+
+    plt.tight_layout(pad=4.0)
+
+    custom_cmap = get_custom_cmap(cmap)
 
     if args.format == "mp4":
         pred_da = fc.isel(time=0).sel(leadtime=leadtimes)
@@ -1760,33 +1776,6 @@ def plot_forecast():
                         # ax_init=plt.axes(projection=ccrs.PlateCarree()) if reproject else None
                         **anim_args)
     else:
-        # TODO: Tidy up code into piecewise functions under `icenet/plotting/utils.py`
-        ax = get_plot_axes(**bound_args,
-                        geoaxes=True,
-                        proj=target_crs if args.crs else None,
-                        set_extents=False if args.region_lat_lon is not None else not args.crs,
-                        )
-
-        if not args.no_coastlines:
-            ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=1)
-            if args.region or args.region_lat_lon:
-                # Higher resolution coastlines when a region is specified
-                ax.add_feature(cfeature.GSHHSFeature(scale="high", levels=[1]), zorder=100)
-            else:
-                ax.coastlines(resolution="10m", zorder=100)
-
-        if args.gridlines:
-            gl = ax.gridlines(crs=transform_crs, draw_labels=True)
-            # Prevent generating labels below the colourbar
-            gl.right_labels = False
-            # # Show gridlines around bounds.
-            # gl.xlocator = mticker.FixedLocator([bound_args["x1"], bound_args["x2"]])
-            # gl.ylocator = mticker.FixedLocator([bound_args["y1"], bound_args["y2"]])
-
-        plt.tight_layout(pad=4.0)
-
-        custom_cmap = get_custom_cmap(cmap)
-
         for i, leadtime in enumerate(leadtimes):
             pred_da = fc.sel(leadtime=leadtime).isel(time=0)
 

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1730,21 +1730,12 @@ def plot_forecast():
         if args.leadtimes is not None \
         else list(range(1, int(max(fc.leadtime.values)) + 1))
 
-    # Define which coastline data to use for plots.
-    # Set to use `GHSS` when specifying a sub-region, else, default `Natural Earth`
-    # coastlines.
-    coastlines = "default"
     if args.region is not None or args.region_geographic is not None:
         extent = (bound_args["x1"], bound_args["x2"], bound_args["y1"], bound_args["y2"])
-        # Note: Using GSHHS coastlines will slow png/mp4 output quite a bit!
-        # This is automatically activated when a sub region is specified with the
-        # '-r' or '-z' region flags.
-        coastlines = "gshhs"
     else:
         extent = None
 
-    if args.no_coastlines:
-        coastlines = None
+    coastlines = not args.no_coastlines
 
     custom_cmap = get_custom_cmap(cmap)
 
@@ -1794,6 +1785,7 @@ def plot_forecast():
                                 target_crs=target_crs
                                 )
         ax = set_plot_geoaxes(ax,
+                              extent=extent,
                               coastlines=coastlines,
                               gridlines=args.gridlines,
                               transform_crs=data_crs_geo,
@@ -1831,7 +1823,7 @@ def plot_forecast():
                             forecast_name,
                             (args.forecast_date + dt.timedelta(days=leadtime)).strftime("%Y%m%d"),
                             "" if not args.stddev else "stddev.", "jpg"))
-                    plt.savefig(output_filename)
+                    plt.savefig(output_filename, dpi=600)
 
                     for handle in region_plot:
                         handle.remove()

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1687,6 +1687,8 @@ def plot_forecast():
         region_args = args.region_lat_lon
         method = "lat_lon"
 
+    # Reproject, and process regions if necessary
+    # TODO: Split thsi function to separate `reproject` and `process_regions`
     fc = process_regions(region_args, [fc], method=method, proj=target_crs, pole=pole, no_clip_region=args.no_clip_region)[0]
 
     vmax = 1.
@@ -1725,9 +1727,10 @@ def plot_forecast():
     if args.no_coastlines:
         coastlines = None
 
-    ax = get_plot_axes(**bound_args,
+    fig, ax = get_plot_axes(**bound_args,
                     geoaxes=True,
                     target_crs=target_crs,
+                    transform_crs=transform_crs,
                     coastlines=coastlines,
                     gridlines=args.gridlines,
                     )
@@ -1766,14 +1769,15 @@ def plot_forecast():
                         if not args.stddev else None,
                         video_path=output_filename,
                         reproject=reproject,
-                        pole=pole,
                         extent=extent,
                         method=method,
-                        coastlines=not args.no_coastlines,
+                        coastlines=coastlines,
                         gridlines=args.gridlines,
                         target_crs=target_crs,
                         transform_crs=transform_crs,
                         # ax_init=plt.axes(projection=ccrs.PlateCarree()) if reproject else None
+                        north=bound_args["north"],
+                        south=bound_args["south"],
                         **anim_args)
     else:
         for i, leadtime in enumerate(leadtimes):
@@ -1781,6 +1785,7 @@ def plot_forecast():
 
             # Standard output plot or using pixel region clipping
             if args.region_lat_lon is None:
+                print("Standard plot")
                 # if args.crs and args.region is not None:
                 #     lon, lat = fc.lon.values, fc.lat.values
                 #     extent = [lon.min(), lon.max(), lat.min(), lat.max()]

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1715,12 +1715,14 @@ def plot_forecast():
                                     y2=args.region_geographic[3])
 
     # Clip the actual data to the requested region if necessary
-    if args.clip_region:
-        fc = process_subregion(region_args,
-                                [fc],
-                                pole,
-                                region_definition=region_definition,
-                            )[0]
+    if not args.clip_region:
+        region_args = None
+
+    fc = process_subregion(region_args,
+                            [fc],
+                            pole,
+                            region_definition=region_definition,
+                        )[0]
 
     vmax = 1.
 

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1839,6 +1839,7 @@ def plot_forecast():
 
                     region_plot = ax.plot(box_lon, box_lat, transform=data_crs_geo, color="red", zorder=999)
                     ax.set_global()
+                    ax.set_title("Selected region reference")
 
                     output_filename = os.path.join(
                         output_path, "{}.{}_reference.{}{}".format(

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -37,7 +37,6 @@ from icenet.plotting.utils import (calculate_extents, filter_ds_by_obs,
                                    get_crs)
 from icenet.plotting.video import xarray_to_video
 
-
 def parse_location_or_region(argument: str):
     separator = ','
     # Allow ValueError to propagate if not given sequence of integers

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -33,7 +33,7 @@ from icenet.plotting.utils import (calculate_extents, filter_ds_by_obs,
                                    get_seas_forecast_init_dates,
                                    geographic_box, show_img,
                                    get_plot_axes, set_plot_geoaxes, process_probes,
-                                   process_regions, get_custom_cmap,
+                                   process_subregion, get_custom_cmap,
                                    get_crs)
 from icenet.plotting.video import xarray_to_video
 
@@ -598,14 +598,14 @@ def compute_metrics_leadtime_avg(metric: str,
             seas = None
 
         if region is not None:
-            seas, fc, obs, masks = process_regions(region,
+            seas, fc, obs, masks = process_subregion(region,
                                         [seas, fc, obs, masks],
                                         region_definition="pixel"
                                         )
         elif region_geographic is not None:
             raise NotImplementedError("Computing this metric with lon/lat region "
                                     "bounds has not been implemented yet.")
-            seas, fc, obs, masks = process_regions(region_geographic,
+            seas, fc, obs, masks = process_subregion(region_geographic,
                                         [seas, fc, obs, masks],
                                         region_definition="geographic"
                                         )
@@ -1511,14 +1511,14 @@ def binary_accuracy():
         seas = None
 
     if args.region is not None:
-        seas, fc, obs, masks = process_regions(args.region,
+        seas, fc, obs, masks = process_subregion(args.region,
                                     [seas, fc, obs, masks],
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
         raise NotImplementedError("Computing this metric with lon/lat region "
                                 "bounds has not been implemented yet.")
-        seas, fc, obs, masks = process_regions(args.region_geographic,
+        seas, fc, obs, masks = process_subregion(args.region_geographic,
                                     [seas, fc, obs, masks],
                                     region_definition="geographic"
                                     )
@@ -1564,14 +1564,14 @@ def sie_error():
         seas = None
 
     if args.region is not None:
-        seas, fc, obs, masks = process_regions(args.region,
+        seas, fc, obs, masks = process_subregion(args.region,
                                     [seas, fc, obs, masks],
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
         raise NotImplementedError("Computing this metric with lon/lat region "
                                 "bounds has not been implemented yet.")
-        seas, fc, obs, masks = process_regions(args.region_geographic,
+        seas, fc, obs, masks = process_subregion(args.region_geographic,
                                     [seas, fc, obs, masks],
                                     region_definition="geographic"
                                     )
@@ -1704,8 +1704,8 @@ def plot_forecast():
                                     y2=args.region_geographic[3])
 
     # Reproject, and clip the actual data to the requested region if necessary
-    # TODO: Split this function to separate `reproject` and `process_regions`
-    fc = process_regions(region_args,
+    # TODO: Split this function to separate `reproject` and `process_subregion`
+    fc = process_subregion(region_args,
                             [fc],
                             region_definition=region_definition,
                             target_crs=target_crs,
@@ -1911,14 +1911,14 @@ def metric_plots():
         seas = None
 
     if args.region is not None:
-        seas, fc, obs, masks = process_regions(args.region,
+        seas, fc, obs, masks = process_subregion(args.region,
                                     [seas, fc, obs, masks],
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
         raise NotImplementedError("Computing this metric with lon/lat region "
                                 "bounds has not been implemented yet.")
-        seas, fc, obs, masks = process_regions(args.region_geographic,
+        seas, fc, obs, masks = process_subregion(args.region_geographic,
                                     [seas, fc, obs, masks],
                                     region_definition="geographic"
                                     )
@@ -2008,14 +2008,14 @@ def sic_error():
     fc = filter_ds_by_obs(fc, obs, args.forecast_date)
 
     if args.region is not None:
-        fc, obs, masks = process_regions(args.region,
+        fc, obs, masks = process_subregion(args.region,
                                     [fc, obs, masks],
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
         raise NotImplementedError("Computing this metric with lon/lat region "
                                 "bounds has not been implemented yet.")
-        fc, obs, masks = process_regions(args.region_geographic,
+        fc, obs, masks = process_subregion(args.region_geographic,
                                     [fc, obs, masks],
                                     region_definition="geographic"
                                     )

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1638,12 +1638,13 @@ def plot_forecast():
     ap.add_argument("--crs",
                         default=None,
                         help="Coordinate Reference System to use for plotting")
-    ap.add_argument("--no-clip-region",
+    ap.add_argument("--clip-region",
                         action="store_true",
                         default=False,
                         help="Whether to clip the data to the region specified by lon/lat,"\
-                            " When enabled, this shows missing values when plotting along boundaries"\
-                            " due to lon/lat curvature. Default is False"
+                            " When enabled, this crops forecast plot to the bounds, can cause"\
+                            " empty pixels across image edges due to lon/lat curvature."\
+                            " Default is False."
                         )
     args = ap.parse_args()
 
@@ -1714,11 +1715,12 @@ def plot_forecast():
                                     y2=args.region_geographic[3])
 
     # Clip the actual data to the requested region if necessary
-    fc = process_subregion(region_args,
-                            [fc],
-                            pole,
-                            region_definition=region_definition,
-                        )[0]
+    if args.clip_region:
+        fc = process_subregion(region_args,
+                                [fc],
+                                pole,
+                                region_definition=region_definition,
+                            )[0]
 
     vmax = 1.
 

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -559,6 +559,8 @@ def compute_metrics_leadtime_avg(metric: str,
 
     :return: pandas dataframe with columns 'date', 'leadtime' and the metric name.
     """
+    pole = 1 if hemisphere == "north" else -1
+
     # open forecast file
     fc_ds = xr.open_dataset(forecast_file)
 
@@ -600,14 +602,15 @@ def compute_metrics_leadtime_avg(metric: str,
         if region is not None:
             seas, fc, obs, masks = process_subregion(region,
                                         [seas, fc, obs, masks],
-                                        region_definition="pixel"
+                                        pole,
+                                        region_definition="pixel",
                                         )
         elif region_geographic is not None:
-            raise NotImplementedError("Computing this metric with lon/lat region "
-                                    "bounds has not been implemented yet.")
             seas, fc, obs, masks = process_subregion(region_geographic,
                                         [seas, fc, obs, masks],
-                                        region_definition="geographic"
+                                        pole,
+                                        src_da=obs,
+                                        region_definition="geographic",
                                         )
 
         # compute metrics
@@ -923,6 +926,7 @@ def plot_metrics_leadtime_avg(metric: str,
                                                  data_path=data_path,
                                                  bias_correct=bias_correct,
                                                  region=region,
+                                                 region_geographic=region_geographic,
                                                  **kwargs)
 
     fc_metric_df = metric_df[metric_df["forecast_name"] == "IceNet"]
@@ -1486,6 +1490,8 @@ def binary_accuracy():
     ap = (ForecastPlotArgParser().allow_ecmwf().allow_threshold())
     args = ap.parse_args()
 
+    pole = 1 if args.hemisphere == "north" else -1
+
     masks = Masks(north=args.hemisphere == "north",
                   south=args.hemisphere == "south")
 
@@ -1513,13 +1519,14 @@ def binary_accuracy():
     if args.region is not None:
         seas, fc, obs, masks = process_subregion(args.region,
                                     [seas, fc, obs, masks],
+                                    pole,
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
-        raise NotImplementedError("Computing this metric with lon/lat region "
-                                "bounds has not been implemented yet.")
         seas, fc, obs, masks = process_subregion(args.region_geographic,
                                     [seas, fc, obs, masks],
+                                    pole,
+                                    src_da=obs,
                                     region_definition="geographic"
                                     )
 
@@ -1539,6 +1546,8 @@ def sie_error():
     ap = (ForecastPlotArgParser().allow_ecmwf().allow_threshold().allow_sie())
     args = ap.parse_args()
 
+    pole = 1 if args.hemisphere == "north" else -1
+
     masks = Masks(north=args.hemisphere == "north",
                   south=args.hemisphere == "south")
 
@@ -1566,13 +1575,14 @@ def sie_error():
     if args.region is not None:
         seas, fc, obs, masks = process_subregion(args.region,
                                     [seas, fc, obs, masks],
+                                    pole,
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
-        raise NotImplementedError("Computing this metric with lon/lat region "
-                                "bounds has not been implemented yet.")
         seas, fc, obs, masks = process_subregion(args.region_geographic,
                                     [seas, fc, obs, masks],
+                                    pole,
+                                    src_da=obs,
                                     region_definition="geographic"
                                     )
 
@@ -1706,6 +1716,7 @@ def plot_forecast():
     # Clip the actual data to the requested region if necessary
     fc = process_subregion(region_args,
                             [fc],
+                            pole,
                             region_definition=region_definition,
                         )[0]
 
@@ -1880,6 +1891,8 @@ def metric_plots():
     ap = (ForecastPlotArgParser().allow_ecmwf().allow_metrics())
     args = ap.parse_args()
 
+    pole = 1 if args.hemisphere == "north" else -1
+
     masks = Masks(north=args.hemisphere == "north",
                   south=args.hemisphere == "south")
 
@@ -1909,13 +1922,14 @@ def metric_plots():
     if args.region is not None:
         seas, fc, obs, masks = process_subregion(args.region,
                                     [seas, fc, obs, masks],
+                                    pole,
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
-        raise NotImplementedError("Computing this metric with lon/lat region "
-                                "bounds has not been implemented yet.")
         seas, fc, obs, masks = process_subregion(args.region_geographic,
                                     [seas, fc, obs, masks],
+                                    pole,
+                                    src_da=obs,
                                     region_definition="geographic"
                                     )
 
@@ -1981,6 +1995,7 @@ def leadtime_avg_plots():
                               target_date_avg=args.target_date_average,
                               bias_correct=args.bias_correct,
                               region=args.region,
+                              region_geographic=args.region_geographic,
                               threshold=args.threshold,
                               grid_area_size=args.grid_area)
 
@@ -1991,6 +2006,8 @@ def sic_error():
     """
     ap = ForecastPlotArgParser()
     args = ap.parse_args()
+
+    pole = 1 if args.hemisphere == "north" else -1
 
     masks = Masks(north=args.hemisphere == "north",
                   south=args.hemisphere == "south")
@@ -2006,13 +2023,14 @@ def sic_error():
     if args.region is not None:
         fc, obs, masks = process_subregion(args.region,
                                     [fc, obs, masks],
+                                    pole,
                                     region_definition="pixel"
                                     )
     elif args.region_geographic is not None:
-        raise NotImplementedError("Computing this metric with lon/lat region "
-                                "bounds has not been implemented yet.")
         fc, obs, masks = process_subregion(args.region_geographic,
                                     [fc, obs, masks],
+                                    pole,
+                                    src_da=obs,
                                     region_definition="geographic"
                                     )
 

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1813,7 +1813,7 @@ def plot_forecast():
                             handle.remove()
 
                     extent = bound_args["x1"], bound_args["x2"], bound_args["y1"], bound_args["y2"]
-                    ax.set_extent(extent)
+                    ax.set_extent(extent, crs=target_crs)
 
             divider = make_axes_locatable(ax)
             # Pass axes_class to set correct colourbar height with cartopy

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1762,11 +1762,10 @@ def plot_forecast():
     else:
         # TODO: Tidy up code into piecewise functions under `icenet/plotting/utils.py`
         ax = get_plot_axes(**bound_args,
-                        do_coastlines=not args.no_coastlines,
+                        geoaxes=True,
                         proj=target_crs if args.crs else None,
                         set_extents=False if args.region_lat_lon is not None else not args.crs,
                         )
-        # ax = plt.axes(projection=target_crs)
 
         if not args.no_coastlines:
             ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=1)
@@ -1829,20 +1828,29 @@ def plot_forecast():
 
                 lon, lat = fc.lon.values, fc.lat.values
 
-                # im = ax.pcolormesh(pred_da.x.values, pred_da.y.values, data, transform=target_crs, vmin=0, vmax=vmax, cmap=custom_cmap)
+                # im = ax.pcolormesh(pred_da.xc.values, pred_da.yc.values, data, transform=data_crs, vmin=0, vmax=vmax, cmap=custom_cmap)
                 # im = pred_da.plot.imshow(ax=ax, transform=transform_crs,
                 #                              vmin=0,
                 #                              vmax=vmax,
                 #                              add_colorbar=False,
                 #                              cmap=custom_cmap,
                 #                              )
-                im = pred_da.plot.pcolormesh("lon",
-                                            "lat",
-                                            ax=ax,
-                                            transform=transform_crs,
-                                            add_colorbar=False,
-                                            cmap=custom_cmap,
-                                            )
+                # im = pred_da.plot.pcolormesh("lon",
+                #                             "lat",
+                #                             ax=ax,
+                #                             transform=transform_crs,
+                #                             add_colorbar=False,
+                #                             cmap=custom_cmap,
+                #                             )
+                im = pred_da.plot.pcolormesh("xc",
+                                             "yc",
+                                             ax=ax,
+                                             transform=target_crs,
+                                             vmin=0,
+                                             vmax=vmax,
+                                             add_colorbar=False,
+                                             cmap=custom_cmap,
+                                             )
                 stored_extent = ax.get_extent()
 
                 # Output a reference image showing cropped region
@@ -1862,7 +1870,10 @@ def plot_forecast():
                     for handle in region_plot:
                         handle.remove()
 
-                extent = bound_args["x1"], bound_args["x2"], bound_args["y1"], bound_args["y2"]
+                extent = [bound_args["x1"], bound_args["x2"], bound_args["y1"], bound_args["y2"]]
+                # With some projections like Mercator, it doesn't like having exact boundary longitude
+                if bound_args["x1"] == -180:
+                    extent[0] = -179.99
                 logging.debug("Forecast plot extent:", extent)
                 ax.set_extent(extent, crs=transform_crs)
 

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1748,14 +1748,6 @@ def plot_forecast():
     if args.no_coastlines:
         coastlines = None
 
-    fig, ax = get_plot_axes(**bound_args,
-                    geoaxes=True,
-                    target_crs=target_crs,
-                    transform_crs=transform_crs,
-                    coastlines=coastlines,
-                    gridlines=args.gridlines,
-                    )
-
     custom_cmap = get_custom_cmap(cmap)
 
     if args.format == "mp4":
@@ -1799,40 +1791,35 @@ def plot_forecast():
                         colorbar_label=colorbar_label,
                         **anim_args)
     else:
+        fig, ax = get_plot_axes(**bound_args,
+                        geoaxes=True,
+                        target_crs=target_crs,
+                        transform_crs=transform_crs,
+                        coastlines=coastlines,
+                        gridlines=args.gridlines,
+                        )
         for i, leadtime in enumerate(leadtimes):
             pred_da = fc.sel(leadtime=leadtime).isel(time=0)
 
-            # Standard output plot or using pixel region clipping
-            if args.region_geographic is None:
-                im = pred_da.plot.pcolormesh("xc",
-                                             "yc",
-                                             ax=ax,
-                                             transform=target_crs,
-                                             vmin=0,
-                                             vmax=vmax,
-                                             add_colorbar=False,
-                                             cmap=custom_cmap,
-                                             )
-            # Using lon/lat region clipping
-            else:
-                lon, lat = fc.lon.values, fc.lat.values
+            im = pred_da.plot.pcolormesh("xc",
+                                            "yc",
+                                            ax=ax,
+                                            transform=target_crs,
+                                            vmin=0,
+                                            vmax=vmax,
+                                            add_colorbar=False,
+                                            cmap=custom_cmap,
+                                            )
 
-                im = pred_da.plot.pcolormesh("xc",
-                                             "yc",
-                                             ax=ax,
-                                             transform=target_crs,
-                                             vmin=0,
-                                             vmax=vmax,
-                                             add_colorbar=False,
-                                             cmap=custom_cmap,
-                                             )
+            if args.region_geographic:
+                # Special case, when using geographic (lon/lat) region clipping
                 stored_extent = ax.get_extent()
 
                 # Output a reference image showing cropped region
                 if i == 0:
                     box_lon, box_lat = geographic_box((bound_args["x1"], bound_args["x2"]), (bound_args["y1"], bound_args["y2"]), segments=10)
 
-                    region_plot = ax.plot(box_lon, box_lat, transform=transform_crs, color="red")
+                    region_plot = ax.plot(box_lon, box_lat, transform=transform_crs, color="red", zorder=999)
                     ax.set_global()
 
                     output_filename = os.path.join(

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1690,9 +1690,11 @@ def plot_forecast():
     ## Clip the actual data to the requested region.
     ## This can cause empty region at the borders if used with different CRS projections
     ## due to re-projection.
-    if args.crs and args.region_lat_lon:
-        logging.warning(f"Using {args.crs} for plot reprojection, this can cause " \
+    if args.crs and args.region_lat_lon and not args.no_clip_region:
+        logging.warning(f"Using '{args.crs}' for plot reprojection, this can cause " \
             "empty regions along the outer edges due to re-projection.")
+        logging.warning(f"You may want to run with '--no-clip-region' to plot full region without " \
+                        "clipping data to only the specifed longitude and latitude bounds.")
 
     # Reproject, and process regions if necessary
     # TODO: Split this function to separate `reproject` and `process_regions`

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1794,7 +1794,6 @@ def plot_forecast():
 
             # Standard output plot or using pixel region clipping
             if args.region_geographic is None:
-                print("Standard plot")
                 im = pred_da.plot.pcolormesh("xc",
                                              "yc",
                                              ax=ax,
@@ -1806,11 +1805,6 @@ def plot_forecast():
                                              )
             # Using lon/lat region clipping
             else:
-                # cmap.set_bad("dimgrey", alpha=0)
-                # Hack since cartopy needs transparency for nan regions to wraparound
-                # correctly with pcolormesh.
-                data = np.where(np.isnan(pred_da), -9999, pred_da)
-
                 lon, lat = fc.lon.values, fc.lat.values
 
                 im = pred_da.plot.pcolormesh("xc",

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1786,7 +1786,7 @@ def plot_forecast():
     else:
         fig, ax = get_plot_axes(**bound_args,
                                 geoaxes=True,
-                                target_crs=target_crs
+                                target_crs=target_crs,
                                 )
         ax = set_plot_geoaxes(ax,
                               extent=extent,
@@ -1794,14 +1794,16 @@ def plot_forecast():
                               gridlines=args.gridlines,
                               transform_crs=data_crs_geo,
                               )
+        # Convert from km to m
+        fc = fc.assign_coords(xc=fc.xc.data * 1000, yc=fc.yc.data * 1000)
 
         for i, leadtime in enumerate(leadtimes):
             pred_da = fc.sel(leadtime=leadtime).isel(time=0)
 
-            im = pred_da.plot.pcolormesh("lon",
-                                         "lat",
+            im = pred_da.plot.pcolormesh("xc",
+                                         "yc",
                                          ax=ax,
-                                         transform=data_crs_geo,
+                                         transform=data_crs_proj,
                                          vmin=0,
                                          vmax=vmax,
                                          add_colorbar=False,

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1792,7 +1792,6 @@ def plot_forecast():
                               extent=extent,
                               coastlines=coastlines,
                               gridlines=args.gridlines,
-                              transform_crs=data_crs_geo,
                               )
         # Convert from km to m
         fc = fc.assign_coords(xc=fc.xc.data * 1000, yc=fc.yc.data * 1000)

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1796,6 +1796,7 @@ def plot_forecast():
         # Convert from km to m
         fc = fc.assign_coords(xc=fc.xc.data * 1000, yc=fc.yc.data * 1000)
 
+        cbar = None
         for i, leadtime in enumerate(leadtimes):
             pred_da = fc.sel(leadtime=leadtime).isel(time=0)
 
@@ -1840,10 +1841,13 @@ def plot_forecast():
                 logging.debug("Forecast plot extent:", extent)
                 ax.set_extent(extent, crs=data_crs_geo)
 
-            divider = make_axes_locatable(ax)
-            # Pass axes_class to set correct colourbar height with cartopy
-            cax = divider.append_axes("right", size="5%", pad=0.05, axes_class=plt.Axes)
-            cbar = plt.colorbar(im, ax=ax, cax=cax)
+            if not cbar:
+                divider = make_axes_locatable(ax)
+                # Pass axes_class to set correct colourbar height with cartopy
+                cax = divider.append_axes("right", size="5%", pad=0.05, axes_class=plt.Axes)
+                cbar = plt.colorbar(im, ax=ax, cax=cax)
+                if colorbar_label:
+                    cbar.set_label(colorbar_label)
 
             plot_date = args.forecast_date + dt.timedelta(leadtime)
             ax.set_title("{:04d}/{:02d}/{:02d}".format(plot_date.year,
@@ -1851,8 +1855,6 @@ def plot_forecast():
                                                        plot_date.day),
                                                        fontsize="large",
                                                        )
-            if colorbar_label:
-                cbar.set_label(colorbar_label)
             plt.subplots_adjust(right=0.9)
             output_filename = os.path.join(
                 output_path, "{}.{}.{}{}".format(

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1701,15 +1701,10 @@ def plot_forecast():
 
     # Reproject, and process regions if necessary
     # TODO: Split this function to separate `reproject` and `process_regions`
-    if reproject:
-        projection = target_crs
-    else:
-        projection = None
-
     fc = process_regions(region_args,
                             [fc],
                             method=method,
-                            target_crs=projection,
+                            target_crs=target_crs,
                             pole=pole,
                             clip_geographic_region=not args.no_clip_region
                         )[0]

--- a/icenet/plotting/forecast.py
+++ b/icenet/plotting/forecast.py
@@ -1677,14 +1677,10 @@ def plot_forecast():
     if args.crs:
         logging.warning(f"Using {args.crs} for plot reprojection, this can cause " \
             "empty regions along the outer edges due to re-projection.")
-    if args.clip_region and args.region is not None:
+    if args.region is not None:
         fc = process_regions(args.region, [fc], method="pixel", proj=target_crs, pole=pole)[0]
-    elif args.clip_region and args.region_lat_lon is not None:
+    elif args.region_lat_lon is not None:
         fc = process_regions(args.region_lat_lon, [fc], method="lat_lon", proj=target_crs, pole=pole)[0]
-
-    transformed_coords = data_crs.transform_points(target_crs, fc.lon.data, fc.lat.data)
-    x = transformed_coords[:, :, 0]
-    y = transformed_coords[:, :, 1]
 
     vmax = 1.
 
@@ -1763,6 +1759,7 @@ def plot_forecast():
                         proj=target_crs if args.crs else None,
                         set_extents=False if args.region_lat_lon is not None else not args.crs,
                         )
+        # ax = plt.axes(projection=target_crs)
 
         if not args.no_coastlines:
             ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=100)
@@ -1791,18 +1788,30 @@ def plot_forecast():
                 if args.crs and args.region is not None:
                     lon, lat = fc.lon.values, fc.lat.values
                     extent = [lon.min(), lon.max(), lat.min(), lat.max()]
-                    # ax.set_extent(extent, crs=transform_crs)
+                    # ax.set_extent(extent, crs=target_crs)
                 else:
                     extent = None
+                # im = pred_da.plot.pcolormesh("x",
+                #                              "y",
+                #                              ax=ax,
+                #                              transform=target_crs,
+                #                              vmin=0,
+                #                              vmax=vmax,
+                #                              add_colorbar=False,
+                #                              cmap=custom_cmap,
+                #                              )
+                # im = pred_da.plot.imshow(ax=ax, transform=target_crs,
+                #                              vmin=0,
+                #                              vmax=vmax,
+                #                              add_colorbar=False,
+                #                              cmap=custom_cmap,
+                #                              )
                 im = pred_da.plot.pcolormesh("lon",
-                                             "lat",
-                                             ax=ax,
-                                             transform=transform_crs,
-                                             vmin=0,
-                                             vmax=vmax,
-                                             add_colorbar=False,
-                                             cmap=custom_cmap,
-                                             )
+                                            "lat",
+                                            ax=ax,
+                                            transform=transform_crs,
+                                            add_colorbar=False,
+                                            )
             # Using lat/lon region clipping
             else:
                 # cmap.set_bad("dimgrey", alpha=0)
@@ -1812,7 +1821,13 @@ def plot_forecast():
 
                 lon, lat = fc.lon.values, fc.lat.values
 
-                im = ax.pcolormesh(x, y, data, transform=target_crs, vmin=0, vmax=vmax, cmap=custom_cmap)
+                # im = ax.pcolormesh(x, y, data, transform=target_crs, vmin=0, vmax=vmax, cmap=custom_cmap)
+                im = pred_da.plot.imshow(ax=ax, transform=target_crs,
+                                             vmin=0,
+                                             vmax=vmax,
+                                             add_colorbar=False,
+                                             cmap=custom_cmap,
+                                             )
                 stored_extent = ax.get_extent()
 
                 # Output a reference image showing cropped region

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -427,7 +427,7 @@ def set_plot_geoaxes(ax,
     # extents = pixel_to_projection(x1, x2, y1, y2, x_min_proj, x_max_proj, y_min_proj, y_max_proj, 432, 432)
     # ax.set_extent(extents, crs=proj)
 
-    # Set colour for areas outside of `process_regions()` - i.e., no data here.
+    # Set colour for areas outside of `process_subregion()` - i.e., no data here.
     ax.set_facecolor('dimgrey')
 
     if coastlines:
@@ -606,7 +606,7 @@ def reproject_projected_coords(data,
     return reprojected_data
 
 
-def process_regions(region: tuple=None,
+def process_subregion(region: tuple=None,
         data: tuple=None,
         region_definition: str = "pixel",
         target_crs=None,
@@ -616,7 +616,7 @@ def process_regions(region: tuple=None,
     """Extract subset of pan-Arctic/Antarctic region based on region bounds.
 
     :param region: Either image pixel bounds, or geographic bounds.
-    :param data: Contains the full xarray DataArray.
+    :param data: Contains list of xarray DataArrays.
     :param region_definition: Whether providing pixel coordinates or geographic (i.e. lon/lat).
     :param clip_geographic_region: Whether to clip the data to the defined lon/lat region bounds.
 
@@ -645,7 +645,6 @@ def process_regions(region: tuple=None,
                             pole=pole,
                             )
                 data[idx] = reprojected_data
-
 
             if region is not None:
                 logging.info(f"Clipping data to specified bounds: {region}")

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -533,10 +533,30 @@ def process_block(block, target_crs):
     return reprojected.drop_vars(["time"])
 
 
-def reproject_projected_coords(data,
-                                target_crs,
-                                pole=1,
-                                ):
+def reproject_projected_coords(data: object,
+                                target_crs: object,
+                                pole: int=1,
+                                ) -> object:
+    """
+    Reprojects an xarray Dataset from LambertAzimuthalEqualArea to `target_crs`.
+
+    The Dataset is expected to have dims of (xc, yc).
+
+    Args:
+        data: xarray dataset with dims (xc, yc), and also coords of lon and lat.
+        target_crs: Cartopy CRS to project to (e.g. `ccrs.Mercator()`)
+        pole: Whether north (`1`) or south pole (`-1`).
+
+    Returns:
+        Reprojected data as an xarray dataset.
+
+    Examples:
+
+    >>> reprojected_data = reproject_projected_coords(arr, # doctest: +SKIP
+    >>>             target_crs=target_crs,
+    >>>             pole=pole,
+    >>>             )
+    """
     # Eastings/Northings projection
     data_crs_proj = ccrs.LambertAzimuthalEqualArea(0, pole*90)
     # geographic projection

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -9,10 +9,13 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import rioxarray
 import xarray as xr
 
 from functools import cache
 from ibicus.debias import LinearScaling
+from pyproj import CRS
+from rasterio.enums import Resampling
 
 
 def broadcast_forecast(start_date: object,
@@ -495,7 +498,92 @@ def process_probes(probes, data) -> tuple:
     return data
 
 
-def process_regions(region: tuple, data: tuple, method: str = "pixel", proj=None, pole=1) -> tuple:
+def reproject_projected_coords(data, target_crs=ccrs.Mercator(), pole=1):
+    if pole == 1:
+        data_crs_proj = ccrs.NorthPolarStereo()
+    elif pole == -1:
+        data_crs_proj = ccrs.SouthPolarStereo()
+    data_crs_geo = ccrs.PlateCarree()
+
+    x_m, y_m = data.xc.values*1000, data.yc.values*1000
+    transformed_coords_proj = target_crs.transform_points(data_crs_proj, x_m, y_m)
+
+    trans_x = transformed_coords_proj[..., 0]
+    trans_y = transformed_coords_proj[..., 1]
+
+    lon, lat = data.lon.values, data.lat.values
+    transformed_coords_proj = target_crs.transform_points(data_crs_geo, lon, lat)
+
+    trans_lon = transformed_coords_proj[..., 0]
+    trans_lat = transformed_coords_proj[..., 1]
+
+    data_crs = ccrs.LambertAzimuthalEqualArea(0, 90)
+    # target_crs = ccrs.epsg("3347")
+    target_crs = ccrs.Mercator()
+    target_crs = ccrs.Mercator.GOOGLE
+    # target_crs = ccrs.PlateCarree()
+    # target_crs = data_crs
+
+    data_reproject = xr.DataArray(
+        data.data,
+                dims=["time", "leadtime", "y", "x"],
+                coords={
+                    "x": data.xc.data*1000,
+                    "y": data.yc.data*1000,
+                    # "lon": (("y", "x"), data.lon.data),
+                    # "lat": (("y", "x"), data.lat.data),
+                    "time": data.time.data,
+                    "leadtime": data.leadtime.data,
+                }
+    )
+
+    data_reproject.rio.set_spatial_dims(x_dim="y", y_dim="x", inplace=True)
+    data_reproject.rio.write_crs(data_crs.proj4_init, inplace=True)
+    data_reproject.rio.write_nodata(np.nan, inplace=True)
+
+    # Reproject to Mercator
+    data_mercator = data_reproject.isel(time=0, leadtime=0).rio.reproject(target_crs.proj4_init,
+        # resampling=Resampling.bilinear,
+        nodata=np.nan
+        )
+
+    # Compute lat/lon for reprojected image
+    data_geo = data_mercator.rio.reproject(data_crs_geo.proj4_init, shape=data_mercator.shape)    
+    lon_grid, lat_grid = np.meshgrid(data_geo.x, data_geo.y)
+
+    data_mercator["lon"] = (("y", "x"), lon_grid)
+    data_mercator["lat"] = (("y", "x"), lat_grid)
+
+    # Define your pixel bounds
+    min_x_pixel = 10
+    max_x_pixel = 150
+    min_y_pixel = 20
+    max_y_pixel = 200
+
+    x_max, y_max = data_mercator.x.shape[0], data_mercator.y.shape[0]
+    max_x_pixel = min(x_max, max_x_pixel)
+    max_y_pixel = min(y_max, max_y_pixel)
+
+    # Clip the data array
+    clipped_data = data_mercator[..., (y_max - max_y_pixel):(y_max - min_y_pixel), min_x_pixel:max_x_pixel]
+
+    # plt.figure(figsize=(10, 10))
+    # ax = plt.axes(projection=target_crs)
+    # clipped_data.plot.imshow(ax=ax, transform=target_crs)
+    # # ax.imshow(clipped_data, transform=ccrs.Mercator.GOOGLE)
+    # ax.coastlines()
+    # ax.set_global()
+    # plt.show()
+
+    return clipped_data
+
+
+def process_regions(region: tuple,
+        data: tuple,
+        method: str = "pixel",
+        proj=None,
+        pole=1,
+    ) -> tuple:
     """Extract subset of pan-Arctic/Antarctic region based on region bounds.
 
     :param region: Either image pixel bounds, or lat/lon bounds.
@@ -511,6 +599,8 @@ def process_regions(region: tuple, data: tuple, method: str = "pixel", proj=None
 
     for idx, arr in enumerate(data):
         if arr is not None:
+            arr = reproject_projected_coords(arr)
+
             if method == "pixel":
                 data[idx] = arr[..., (432 - y2):(432 - y1), x1:x2]
 

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -430,11 +430,6 @@ def set_plot_geoaxes(ax,
                   ):
     plt.tight_layout(pad=4.0)
 
-    # extents = pixel_to_projection(x1, x2, y1, y2, x_min_proj, x_max_proj, y_min_proj, y_max_proj, 432, 432)
-    # ax.set_extent(extents, crs=proj)
-
-    #set_plot_geoextent(ax, extent)
-
     # Set colour for areas outside of `process_subregion()` - i.e., no data here.
     ax.set_facecolor("dimgrey")
 
@@ -473,12 +468,6 @@ def set_plot_geoaxes(ax,
         # Prevent generating labels beneath the colourbar
         gl.top_labels = False
         gl.right_labels = False
-
-    # # Plot polygon overlaying custom boundary region
-    #clipped_boundary = ShapelyFeature([clipping_polygon], ccrs.PlateCarree(), facecolor="orange")
-    #ax.add_feature(clipped_boundary, zorder=100)
-    # # Clip axis to custom lat/lon boundary shape
-    #ax.set_boundary(path, transform=ccrs.PlateCarree())
 
     return ax
 

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -446,7 +446,7 @@ def set_plot_geoaxes(ax,
 
     if coastlines:
         auto_scaler = AdaptiveScaler("110m", (("50m", 150), ("10m", 50)))
-        land = NaturalEarthFeature("physical", "land", scale="10m")
+        land = NaturalEarthFeature("physical", "land", scale="10m", facecolor="dimgrey")
         if extent:
             clipped_land = ShapelyFeature([clipping_polygon.intersection(geom)
                                            for geom in land.geometries()],

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -7,6 +7,7 @@ import re
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
 import dask.array as da
+import imageio_ffmpeg as ffmpeg
 import matplotlib as mpl
 import matplotlib.patches as patches
 import matplotlib.pyplot as plt
@@ -845,3 +846,8 @@ def get_custom_cmap(cmap):
     custom_cmap.set_bad("dimgrey", alpha=0)
     custom_cmap.set_under("dimgrey")
     return custom_cmap
+
+def set_ffmpeg_path():
+    """Set Matplotlib's ffmpeg exe path to the one from imageio_ffmpeg"""
+    ffmpeg_path = ffmpeg.get_ffmpeg_exe()
+    plt.rcParams['animation.ffmpeg_path'] = ffmpeg_path

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -424,7 +424,7 @@ def get_plot_axes(x1: int = 0,
 
 
 def set_plot_geoaxes(ax,
-                  extent: list,
+                  extent: list = None,
                   coastlines: str = None,
                   gridlines: bool = False,
                   transform_crs: object = ccrs.PlateCarree(),
@@ -439,21 +439,23 @@ def set_plot_geoaxes(ax,
     # Set colour for areas outside of `process_subregion()` - i.e., no data here.
     ax.set_facecolor("dimgrey")
 
-    lon_min, lon_max, lat_min, lat_max = extent
-    ax.set_extent([lon_min, lon_max, lat_min, lat_max], crs=ccrs.PlateCarree())
-    clipping_polygon = Polygon(get_geoextent_polygon(extent))
-    path = Path(np.array(clipping_polygon.exterior.coords))
+    if extent:
+        lon_min, lon_max, lat_min, lat_max = extent
+        ax.set_extent([lon_min, lon_max, lat_min, lat_max], crs=ccrs.PlateCarree())
+        clipping_polygon = Polygon(get_geoextent_polygon(extent))
+        path = Path(np.array(clipping_polygon.exterior.coords))
 
     if coastlines:
         land = NaturalEarthFeature("physical", "land", scale="10m", facecolor="dimgrey")
-        clipped_land = ShapelyFeature([clipping_polygon.intersection(geom)
-                                       for geom in land.geometries()],
-                                       ccrs.PlateCarree(), facecolor="dimgrey")
-
-        ax.add_feature(clipped_land, zorder=100)
-
-        # Draw coastlines explicitly within the clipping region
-        ax.add_geometries([clipping_polygon], ccrs.PlateCarree(), edgecolor="black", facecolor="none", linewidth=0.8, zorder=2)
+        if extent:
+            clipped_land = ShapelyFeature([clipping_polygon.intersection(geom)
+                                           for geom in land.geometries()],
+                                           ccrs.PlateCarree(), facecolor="dimgrey")
+            ax.add_feature(clipped_land, zorder=100)
+            # Draw coastlines explicitly within the clipping region
+            ax.add_geometries([clipping_polygon], ccrs.PlateCarree(), edgecolor="black", facecolor="none", linewidth=0.8, zorder=2)
+        else:
+            ax.add_feature(land, zorder=100)
 
         # Add OSMnx GeoDataFrame of coastlines
         #gdf = ox.features_from_place("Antarctica", tags={"natural": "coastline"})

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -387,10 +387,7 @@ def get_plot_axes(x1: int = 0,
                   north: bool = True,
                   south: bool = False,
                   geoaxes: bool = True,
-                  coastlines: str = None,
-                  gridlines: bool = True,
                   target_crs: object = None,
-                  transform_crs: object = ccrs.PlateCarree(),
                   figsize: int = (10, 8),
                   dpi: int = 150,
                   ):
@@ -403,7 +400,7 @@ def get_plot_axes(x1: int = 0,
     :param geoaxes:
     :return:
     """
-    assert north ^ south, "One hemisphere only must be selected"
+    assert north ^ south, "Only one hemisphere must be selected"
 
     fig = plt.figure(figsize=figsize, dpi=dpi, layout="tight")
 
@@ -411,36 +408,43 @@ def get_plot_axes(x1: int = 0,
         # pole = 1 if north else -1
         # target_crs, x_min_proj, x_max_proj, y_min_proj, y_max_proj = get_bounds(target_crs, pole)
         pole = 1 if north else -1
-        target_crs = ccrs.LambertAzimuthalEqualArea(central_latitude=pole*90, central_longitude=0) if target_crs is None else target_crs
+        proj = ccrs.LambertAzimuthalEqualArea(central_latitude=pole*90, central_longitude=0) if target_crs is None else target_crs
 
-        ax = fig.add_subplot(1, 1, 1, projection=target_crs)
-        plt.tight_layout(pad=4.0)
-
-        # extents = pixel_to_projection(x1, x2, y1, y2, x_min_proj, x_max_proj, y_min_proj, y_max_proj, 432, 432)
-        # ax.set_extent(extents, crs=proj)
-
-        # Set colour for areas outside of `process_regions()` - no data here.
-        ax.set_facecolor('dimgrey')
-
-        if coastlines:
-            ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=1)
-            if isinstance(coastlines, str) and coastlines.casefold() == "gshhs":
-                # Higher resolution coastlines when a region is specified
-                ax.add_feature(cfeature.GSHHSFeature(scale="auto", levels=[1]), zorder=100)
-            elif isinstance(coastlines, bool) or coastlines.casefold() == "default":
-                ax.coastlines(resolution="50m", zorder=100)
-
-        if gridlines:
-            gl = ax.gridlines(crs=transform_crs, draw_labels=True)
-            # Prevent generating labels beneath the colourbar
-            gl.top_labels = False
-            gl.right_labels = False
-
+        ax = fig.add_subplot(1, 1, 1, projection=proj)
     else:
         ax = fig.add_subplot(1, 1, 1)
 
     return fig, ax
 
+
+def set_plot_geoaxes(ax,
+                  coastlines: str = None,
+                  gridlines: bool = False,
+                  transform_crs: object = ccrs.PlateCarree(),
+                  ):
+    plt.tight_layout(pad=4.0)
+
+    # extents = pixel_to_projection(x1, x2, y1, y2, x_min_proj, x_max_proj, y_min_proj, y_max_proj, 432, 432)
+    # ax.set_extent(extents, crs=proj)
+
+    # Set colour for areas outside of `process_regions()` - i.e., no data here.
+    ax.set_facecolor('dimgrey')
+
+    if coastlines:
+        ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=1)
+        if isinstance(coastlines, str) and coastlines.casefold() == "gshhs":
+            # Higher resolution coastlines when a region is specified
+            ax.add_feature(cfeature.GSHHSFeature(scale="auto", levels=[1]), zorder=100)
+        elif isinstance(coastlines, bool) or coastlines.casefold() == "default":
+            ax.coastlines(resolution="50m", zorder=100)
+
+    if gridlines:
+        gl = ax.gridlines(crs=transform_crs, draw_labels=True)
+        # Prevent generating labels beneath the colourbar
+        gl.top_labels = False
+        gl.right_labels = False
+
+    return ax
 
 def show_img(ax,
              arr,

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -543,7 +543,7 @@ def reproject_projected_coords(data,
                                 })
 
     # Need to use correctly scaled xc and yc to get coastlines working even if not reprojecting.
-    # So, just return scaled DataArray back and not reproject.
+    # So, just return scaled DataArray back and not reproject if don't need to.
     if target_crs == data_crs_proj:
         return data_reproject
 
@@ -574,6 +574,7 @@ def reproject_projected_coords(data,
         leadtime_data = xr.map_blocks(process_block, data_reproject.isel(time=time), template=template, kwargs={"target_crs": target_crs})
         reprojected_data.append(leadtime_data)
 
+    # TODO: Add projection info into DataArray, like the `Lambert_Azimuthal_Grid` dropped above
     reprojected_data = xr.concat(reprojected_data, dim="time")
     reprojected_data.coords["time"] = data_reproject.time.data
 

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -404,12 +404,12 @@ def get_plot_axes(x1: int = 0,
     :return:
     """
     assert north ^ south, "One hemisphere only must be selected"
-    pole = 1 if north else -1
 
-    fig = plt.figure(figsize=figsize, dpi=dpi, layout='tight')
+    fig = plt.figure(figsize=figsize, dpi=dpi, layout="tight")
 
     if geoaxes:
-        target_crs, x_min_proj, x_max_proj, y_min_proj, y_max_proj = get_bounds(target_crs, pole)
+        # pole = 1 if north else -1
+        # target_crs, x_min_proj, x_max_proj, y_min_proj, y_max_proj = get_bounds(target_crs, pole)
 
         ax = fig.add_subplot(1, 1, 1, projection=target_crs)
 

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -604,7 +604,7 @@ def reproject_projected_coords(data,
 
 def process_regions(region: tuple=None,
         data: tuple=None,
-        method: str = "pixel",
+        region_definition: str = "pixel",
         target_crs=None,
         pole=1,
         clip_geographic_region=True,
@@ -613,7 +613,7 @@ def process_regions(region: tuple=None,
 
     :param region: Either image pixel bounds, or geographic bounds.
     :param data: Contains the full xarray DataArray.
-    :param method: Whether providing pixel coordinates or geographic (i.e. lon/lat).
+    :param region_definition: Whether providing pixel coordinates or geographic (i.e. lon/lat).
     :param clip_geographic_region: Whether to clip the data to the defined lon/lat region bounds.
 
     :return:
@@ -623,7 +623,7 @@ def process_regions(region: tuple=None,
         assert len(region) == 4, "Region needs to be a list of four integers"
         x1, y1, x2, y2 = region
         assert x2 > x1 and y2 > y1, "Region is not valid"
-        if method == "geographic":
+        if region_definition == "geographic":
             assert x1 >= -180 and x2 <= 180, "Expect longitude range to be `-180<=longitude>=180`"
 
     if target_crs is None:
@@ -631,7 +631,7 @@ def process_regions(region: tuple=None,
 
     for idx, arr in enumerate(data):
         if arr is not None:
-            if (method == "geographic" and clip_geographic_region):
+            if (region_definition == "geographic" and clip_geographic_region):
                 # Reproject when region is bounded by lon/lat without the 'clip_geographic_region' flag
                 data[idx] = arr
             else:
@@ -645,7 +645,7 @@ def process_regions(region: tuple=None,
 
             if region is not None:
                 logging.info(f"Clipping data to specified bounds: {region}")
-                if method.casefold() == "geographic":
+                if region_definition.casefold() == "geographic":
                     if clip_geographic_region:
                         # Limit to lon/lat region, within a given tolerance
                         tolerance = 1E-1
@@ -661,13 +661,13 @@ def process_regions(region: tuple=None,
                                                     target_crs=target_crs,
                                                     pole=pole,
                                                     )
-                elif method.casefold() == "pixel":
+                elif region_definition.casefold() == "pixel":
                     x_max, y_max = reprojected_data.xc.shape[0], reprojected_data.yc.shape[0]
 
                     # Clip the data array to specified pixel region
                     data[idx] = reprojected_data[..., (y_max - y2):(y_max - y1), x1:x2]
                 else:
-                    raise NotImplementedError("Only method='pixel' or 'geographic' bounds are supported")
+                    raise NotImplementedError("Only region_definition='pixel' or 'geographic' bounds are supported")
 
     return data
 

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -693,13 +693,13 @@ def lat_lon_box(lon_bounds: np.array, lat_bounds: np.array, segments: int=1):
 
     return lats, lons
 
-def get_custom_cmap(cmap, vmin=0, vmax=1):
-    """Creates a new colormap for valid array with range 0-1, but with nan set to <0.
+def get_custom_cmap(cmap):
+    """Creates a new colormap, but with nan set to <0.
 
     Hack since cartopy needs transparency for nan regions to wraparound
         correctly with pcolormesh.
     """
-    colors = cmap(np.linspace(vmin, vmax, cmap.N))
+    colors = cmap(np.linspace(0, 1, cmap.N))
     custom_cmap = mpl.colors.ListedColormap(colors)
     custom_cmap.set_bad("dimgrey", alpha=0)
     custom_cmap.set_under("dimgrey")

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -637,9 +637,11 @@ def process_regions(region: tuple=None,
                 elif method.casefold() == "geographic" and not no_clip_region:
                     arr = reprojected_data
 
+                    # Limit to lon/lat region, within a given tolerance
+                    tolerance = 1E-1
                     # Create condition where data is within geographic (lon/lat) region
-                    condition = (arr.lon >= x1) & (arr.lon <= x2) & \
-                                (arr.lat >= y1) & (arr.lat <= y2)
+                    condition = (arr.lon >= x1-tolerance) & (arr.lon <= x2+tolerance) & \
+                                (arr.lat >= y1-tolerance) & (arr.lat <= y2+tolerance)
 
                     # Extract subset within region using where()
                     clipped_data = arr.where(condition, drop=True)

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -391,6 +391,8 @@ def get_plot_axes(x1: int = 0,
                   gridlines: bool = True,
                   target_crs: object = ccrs.Mercator(),
                   transform_crs: object = ccrs.PlateCarree(),
+                  figsize: int = (10, 8),
+                  dpi: int = 150,
                   ):
     """
 
@@ -404,7 +406,7 @@ def get_plot_axes(x1: int = 0,
     assert north ^ south, "One hemisphere only must be selected"
     pole = 1 if north else -1
 
-    fig = plt.figure(figsize=(10, 8), dpi=150, layout='tight')
+    fig = plt.figure(figsize=figsize, dpi=dpi, layout='tight')
 
     if geoaxes:
         target_crs, x_min_proj, x_max_proj, y_min_proj, y_max_proj = get_bounds(target_crs, pole)
@@ -433,7 +435,7 @@ def get_plot_axes(x1: int = 0,
     else:
         ax = fig.add_subplot(1, 1, 1)
 
-    return ax
+    return fig, ax
 
 
 def show_img(ax,

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -16,6 +16,7 @@ import rioxarray
 import xarray as xr
 
 from cartopy.feature import ShapelyFeature, NaturalEarthFeature
+from cartopy.feature import AdaptiveScaler
 from functools import cache
 from ibicus.debias import LinearScaling
 from matplotlib.path import Path
@@ -447,7 +448,7 @@ def set_plot_geoaxes(ax,
         land = NaturalEarthFeature("physical", "land", scale="10m", facecolor="dimgrey")
         clipped_land = ShapelyFeature([clipping_polygon.intersection(geom)
                                        for geom in land.geometries()],
-                                       ccrs.PlateCarree(), facecolor="dimgrey", edgecolor="black")
+                                       ccrs.PlateCarree(), facecolor="dimgrey")
 
         ax.add_feature(clipped_land, zorder=100)
 
@@ -457,7 +458,8 @@ def set_plot_geoaxes(ax,
         # Add OSMnx GeoDataFrame of coastlines
         #gdf = ox.features_from_place("Antarctica", tags={"natural": "coastline"})
         #gdf.plot(ax=ax, facecolor='none', edgecolor='black', linewidth=0.5)
-        ax.coastlines(resolution="auto", zorder=100)
+        auto_scaler = AdaptiveScaler("110m", (("50m", 150), ("10m", 50)))
+        ax.coastlines(resolution=auto_scaler, zorder=100)
 
     if gridlines:
         gl = ax.gridlines(crs=transform_crs, draw_labels=True)

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -429,7 +429,7 @@ def get_plot_axes(x1: int = 0,
 
         if gridlines:
             gl = ax.gridlines(crs=transform_crs, draw_labels=True)
-            # Prevent generating labels below the colourbar
+            # Prevent generating labels beneath the colourbar
             gl.right_labels = False
 
     else:

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -446,7 +446,7 @@ def set_plot_geoaxes(ax,
 
     if coastlines:
         auto_scaler = AdaptiveScaler("110m", (("50m", 150), ("10m", 50)))
-        land = NaturalEarthFeature("physical", "land", scale=auto_scaler, facecolor="dimgrey", edgecolor="black")
+        land = NaturalEarthFeature("physical", "land", scale="10m")
         if extent:
             clipped_land = ShapelyFeature([clipping_polygon.intersection(geom)
                                            for geom in land.geometries()],
@@ -478,8 +478,6 @@ def get_geoextent_polygon(extent, crs=ccrs.PlateCarree(), n_points=100):
     Define the number of interpolation points for the curves
     """
     lon_min, lon_max, lat_min, lat_max = extent
-
-    n_points = 100
 
     # Create arrays for the curved sections
     lon_values_bottom = np.linspace(lon_min, lon_max, n_points)

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -350,7 +350,9 @@ def get_plot_axes(x1: int = 0,
     if do_coastlines:
         pole = 1 if north else -1
         proj = ccrs.LambertAzimuthalEqualArea(0, pole * 90) if proj is None else proj
-        ax = fig.add_subplot(1, 1, 1, projection=proj)
+        print(":-:"*50)
+        print("Projection:", proj)
+        ax = fig.add_subplot(1, 1, 1, projection=ccrs.Mercator())
         if set_extents:
             extents = calculate_extents(x1, x2, y1, y2)
             ax.set_extent(extents, crs=proj)

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -445,23 +445,20 @@ def process_regions(region: tuple, data: tuple, method: str = "pixel") -> tuple:
     x1, y1, x2, y2 = region
     assert x2 > x1 and y2 > y1, "Region is not valid"
 
-    if method == "pixel":
-        for idx, arr in enumerate(data):
-            if arr is not None:
+    for idx, arr in enumerate(data):
+        if arr is not None:
+            if method == "pixel":
                 data[idx] = arr[..., (432 - y2):(432 - y1), x1:x2]
-        return data
-    elif method == "lat_lon":
-        for idx, arr in enumerate(data):
-            if arr is not None:
+            elif method == "lat_lon":
                 # Create condition where data is within lat/lon region
                 condition = (arr.lat >= x1) & (arr.lat <= x2) & (arr.lon >= y1) & (arr.lon <= y2)
 
                 # Extract subset within region using where()
-                data[idx] = arr.where(condition, drop=True)
+                data[idx] = arr.where(condition.compute(), drop=True)
+            else:
+                raise NotImplementedError
 
-        return data
-    else:
-        raise NotImplementedError
+    return data
 
 
 @cache

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -423,9 +423,9 @@ def get_plot_axes(x1: int = 0,
             ax.add_feature(cfeature.LAND, facecolor="dimgrey", zorder=1)
             if coastlines.casefold() == "gshhs":
                 # Higher resolution coastlines when a region is specified
-                ax.add_feature(cfeature.GSHHSFeature(scale="high", levels=[1]), zorder=100)
+                ax.add_feature(cfeature.GSHHSFeature(scale="auto", levels=[1]), zorder=100)
             else:
-                ax.coastlines(resolution="10m", zorder=100)
+                ax.coastlines(resolution="50m", zorder=100)
 
         if gridlines:
             gl = ax.gridlines(crs=transform_crs, draw_labels=True)

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -352,7 +352,7 @@ def get_plot_axes(x1: int = 0,
         proj = ccrs.LambertAzimuthalEqualArea(0, pole * 90) if proj is None else proj
         print(":-:"*50)
         print("Projection:", proj)
-        ax = fig.add_subplot(1, 1, 1, projection=ccrs.Mercator())
+        ax = fig.add_subplot(1, 1, 1, projection=proj)
         if set_extents:
             extents = calculate_extents(x1, x2, y1, y2)
             ax.set_extent(extents, crs=proj)
@@ -373,7 +373,10 @@ def show_img(ax,
              vmin: float = 0.,
              vmax: float = 1.,
              north: bool = True,
-             south: bool = False):
+             south: bool = False,
+             crs: object = None,
+             extents: list = None
+             ):
     """
 
     :param ax:

--- a/icenet/plotting/utils.py
+++ b/icenet/plotting/utils.py
@@ -430,7 +430,7 @@ def set_plot_geoaxes(ax,
                   ):
     plt.tight_layout(pad=4.0)
 
-    # Set colour for areas outside of `process_subregion()` - i.e., no data here.
+    # Set colour for areas outside of `process_region()` - i.e., no data here.
     ax.set_facecolor("dimgrey")
 
     if extent:
@@ -719,7 +719,7 @@ def projection_to_geographic_coords(data, target_crs):
     return data
 
 
-def process_subregion(region: tuple=None,
+def process_region(region: tuple=None,
         data: tuple=None,
         pole: int=1,
         src_da: object=None,

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -90,7 +90,7 @@ def xarray_to_video(
     data_type: str = 'abs',
     video_dates: object = None,
     cmap: object = plt.get_cmap("viridis"),
-    figsize: int = (12, 12),
+    figsize: tuple = None,
     dpi: int = 150,
     imshow_kwargs: dict = None,
     ax_init: object = None,
@@ -123,6 +123,8 @@ def xarray_to_video(
     :param ax_init: pre-initialised axes object for display
     :param ax_extra: Extra method called with axes for additional plotting
     """
+    assert north ^ south, "Only one hemisphere must be selected"
+    pole = 1 if north else -1
 
     target_crs = ccrs.LambertAzimuthalEqualArea(central_latitude=pole*90, central_longitude=0) if target_crs is None else target_crs
     transform_crs = ccrs.PlateCarree() if transform_crs is None else transform_crs
@@ -228,16 +230,16 @@ def xarray_to_video(
 
     image_title = ax.set_title("{:04d}/{:02d}/{:02d}".format(
         date.year, date.month, date.day),
-                               fontsize="medium",
+                               fontsize="large",
                                zorder=2)
 
     try:
         divider = make_axes_locatable(ax)
-        cax = divider.append_axes('right', size='5%', pad=0.1, zorder=2, axes_class=plt.Axes)
-        cbar = plt.colorbar(image, cax)
+        cax = divider.append_axes("right", size="5%", pad=0.05, zorder=2, axes_class=plt.Axes)
+        cbar = plt.colorbar(image, ax=ax, cax=cax)
         if colorbar_label:
             cbar.set_label(colorbar_label)
-            fig.subplots_adjust(right=0.85)
+        plt.subplots_adjust(right=0.5)
     except KeyError as ex:
         logging.warning("Could not configure locatable colorbar: {}".format(ex))
 

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -217,11 +217,12 @@ def xarray_to_video(
                                     "yc",
                                     ax=ax,
                                     transform=target_crs,
-                                    clim=(n_min, n_max),
                                     animated=True,
                                     zorder=1,
                                     add_colorbar=False,
                                     cmap=custom_cmap,
+                                    vmin=n_min,
+                                    vmax=n_max,
                                     **imshow_kwargs if imshow_kwargs is not None else {}
                                     )
 
@@ -232,7 +233,7 @@ def xarray_to_video(
 
     try:
         divider = make_axes_locatable(ax)
-        cax = divider.append_axes('right', size='5%', pad=0.05, zorder=2, axes_class=plt.Axes)
+        cax = divider.append_axes('right', size='5%', pad=0.1, zorder=2, axes_class=plt.Axes)
         cbar = plt.colorbar(image, cax)
         if colorbar_label:
             cbar.set_label(colorbar_label)

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -201,12 +201,12 @@ def xarray_to_video(
     if ax_extra is not None:
         ax_extra(ax)
 
+    if extent and method == "lat_lon":
+        ax.set_extent(extent, crs=transform_crs)
+
     date = pd.Timestamp(da.time.values[0]).to_pydatetime()
 
     data = da.sel(time=date)
-
-    if extent and method == "lat_lon":
-        ax.set_extent(extent, crs=transform_crs)
 
     # TODO: Tidy up, and cover all argument options
     # Hack since cartopy needs transparency for nan regions to wraparound
@@ -248,6 +248,7 @@ def xarray_to_video(
                             frames=video_dates,
                             interval=1000 / fps,
                             repeat=False,
+                            blit=True,
                             )
 
     plt.close()

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -127,13 +127,14 @@ def xarray_to_video(
     target_crs = ccrs.LambertAzimuthalEqualArea(central_latitude=pole*90, central_longitude=0) if target_crs is None else target_crs
     transform_crs = ccrs.PlateCarree() if transform_crs is None else transform_crs
 
+    # Hack since cartopy needs transparency for nan regions to wraparound
+    # correctly with pcolormesh, set nan areas as under range.
+    if reproject:
+        da = da.where(~np.isnan(da), -9999, drop=False)
+
     def update(date):
         logging.debug("Plotting {}".format(date.strftime("%D")))
         data = da.sel(time=date)
-        # Hack since cartopy needs transparency for nan regions to wraparound
-        # correctly with pcolormesh.
-        if reproject:
-            data = np.where(np.isnan(data), -9999, data)
         image.set_array(data)
 
         image_title.set_text("{:04d}/{:02d}/{:02d}".format(

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -18,7 +18,7 @@ from mpl_toolkits.axes_grid1 import make_axes_locatable
 
 from icenet.process.predict import get_refcube
 from icenet.utils import setup_logging
-from icenet.plotting.utils import get_plot_axes, set_plot_geoaxes, get_custom_cmap
+from icenet.plotting.utils import get_plot_axes, set_plot_geoaxes, set_plot_geoextent, get_custom_cmap
 
 # TODO: This can be a plotting or analysis util function elsewhere
 def get_dataarray_from_files(files: object, numpy: bool = False) -> object:
@@ -185,6 +185,7 @@ def xarray_to_video(
                             dpi=dpi,
                             )
         ax = set_plot_geoaxes(ax,
+                              extent=extent,
                               coastlines=coastlines,
                               gridlines=gridlines,
                               transform_crs=transform_crs,
@@ -199,8 +200,9 @@ def xarray_to_video(
     if ax_extra is not None:
         ax_extra(ax)
 
-    if extent and region_definition == "geographic":
-        ax.set_extent(extent, crs=transform_crs)
+    #if extent and region_definition == "geographic":
+    #    # ax.set_extent(extent, crs=transform_crs)
+    #    set_plot_geoextent(ax, extent)
 
     date = pd.Timestamp(da.time.values[0]).to_pydatetime()
 

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -242,8 +242,12 @@ def xarray_to_video(
     logging.info("Animating")
 
     # Investigated blitting, but it causes a few problems with masks/titles.
-    animation = FuncAnimation(fig, update, video_dates,
-                            interval=1000 / fps)
+    animation = FuncAnimation(fig,
+                            func=update,
+                            frames=video_dates,
+                            interval=1000 / fps,
+                            repeat=False,
+                            )
 
     plt.close()
 

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -211,7 +211,9 @@ def xarray_to_video(
         # ax.add_feature(cfeature.COASTLINE)
 
     if gridlines:
-        gl = ax.gridlines(crs=transform_crs)
+        gl = ax.gridlines(crs=transform_crs, draw_labels=True)
+        # Prevent generating labels below the colourbar
+        gl.right_labels = False
 
     data = da.sel(time=date)
     lon, lat = da.lon.values, da.lat.values

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -191,12 +191,6 @@ def xarray_to_video(
         ax = ax_init
         fig = ax.get_figure()
 
-    if mask is not None:
-        if mask_type == 'contour':
-            ax.contour(mask, levels=[.5, 1], colors='k', zorder=3)
-        elif mask_type == 'contourf':
-            ax.contourf(mask, levels=[.5, 1], colors='k', zorder=3)
-
     ax.axes.xaxis.set_visible(False)
     ax.axes.yaxis.set_visible(False)
 
@@ -209,6 +203,22 @@ def xarray_to_video(
     date = pd.Timestamp(da.time.values[0]).to_pydatetime()
 
     data = da.sel(time=date)
+
+    if mask is not None:
+        if mask_type == 'contour':
+            image = ax.contour(data.xc.data, data.yc.data, mask,
+                                levels=[.5, 1],
+                                colors='k',
+                                transform=target_crs,
+                                zorder=3,
+                                )
+        elif mask_type == 'contourf':
+            image = ax.contourf(data.xc.data, data.yc.data, mask,
+                                levels=[.5, 1],
+                                colors='k',
+                                transform=target_crs,
+                                zorder=3,
+                                )
 
     # TODO: Tidy up, and cover all argument options
     # Hack since cartopy needs transparency for nan regions to wraparound

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -90,7 +90,7 @@ def xarray_to_video(
     data_type: str = 'abs',
     video_dates: object = None,
     cmap: object = plt.get_cmap("viridis"),
-    figsize: tuple = None,
+    figsize: tuple = (10, 8),
     dpi: int = 150,
     imshow_kwargs: dict = None,
     ax_init: object = None,

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -203,7 +203,7 @@ def xarray_to_video(
     if ax_extra is not None:
         ax_extra(ax)
 
-    if extent and method == "lat_lon":
+    if extent and method == "geographic":
         ax.set_extent(extent, crs=transform_crs)
 
     date = pd.Timestamp(da.time.values[0]).to_pydatetime()
@@ -239,7 +239,7 @@ def xarray_to_video(
         cbar = plt.colorbar(image, ax=ax, cax=cax)
         if colorbar_label:
             cbar.set_label(colorbar_label)
-        plt.subplots_adjust(right=0.5)
+        plt.subplots_adjust(right=0.9)
     except KeyError as ex:
         logging.warning("Could not configure locatable colorbar: {}".format(ex))
 

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -8,7 +8,6 @@ from concurrent.futures import as_completed, ProcessPoolExecutor
 
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
-import imageio_ffmpeg as ffmpeg
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -277,9 +276,6 @@ def xarray_to_video(
         logging.info("Not saving plot, will return animation")
     else:
         logging.info("Saving plot to {}".format(video_path))
-        # Set Matplotlib's ffmpeg executable path to the one from imageio_ffmpeg
-        ffmpeg_path = ffmpeg.get_ffmpeg_exe()
-        plt.rcParams['animation.ffmpeg_path'] = ffmpeg_path
         animation.save(video_path, fps=fps, extra_args=['-vcodec', 'libx264'])
     return animation
 

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -203,7 +203,6 @@ def xarray_to_video(
     date = pd.Timestamp(da.time.values[0]).to_pydatetime()
 
     data = da.sel(time=date)
-    lon, lat = da.lon.values, da.lat.values
 
     if extent and method == "lat_lon":
         ax.set_extent(extent, crs=transform_crs)
@@ -213,14 +212,17 @@ def xarray_to_video(
     # correctly with pcolormesh.
     custom_cmap = get_custom_cmap(cmap)
 
-    image = ax.pcolormesh(lon, lat, data,
-                            transform=transform_crs,
-                            cmap=custom_cmap,
-                            clim=(n_min, n_max),
-                            animated=True,
-                            zorder=1,
-                            **imshow_kwargs if imshow_kwargs is not None else {}
-                            )
+    image = data.plot.pcolormesh("xc",
+                                    "yc",
+                                    ax=ax,
+                                    transform=target_crs,
+                                    clim=(n_min, n_max),
+                                    animated=True,
+                                    zorder=1,
+                                    add_colorbar=False,
+                                    cmap=custom_cmap,
+                                    **imshow_kwargs if imshow_kwargs is not None else {}
+                                    )
 
     image_title = ax.set_title("{:04d}/{:02d}/{:02d}".format(
         date.year, date.month, date.day),

--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -188,7 +188,6 @@ def xarray_to_video(
                               extent=extent,
                               coastlines=coastlines,
                               gridlines=gridlines,
-                              transform_crs=transform_crs,
                               )
     else:
         ax = ax_init


### PR DESCRIPTION
Resolves #279 and #100 

* Uses Cartopy to enable north-facing plots.
* Enable defining region for forecast output based on lat/lon bounds and not just pixel bounds.
* Enable gridlines optionally.
* Enable coastlines with mp4 animation output (Fixing #100).

There is still work to be done on using the lat/lon which will likely need some refactoring of the `Masks` class. When `process_regions` is called and `Masks` is provided to it here:

https://github.com/icenet-ai/icenet/blob/f1285368eb731ed473c6b574b1d48ae574a8c01e/icenet/plotting/forecast.py#L1486-L1488

It defines a pixel based slice which is set by `getitem` in the Masks class. (This is the case for all times `process_regions` is called in `forecast.py` above)

https://github.com/icenet-ai/icenet/blob/f1285368eb731ed473c6b574b1d48ae574a8c01e/icenet/data/sic/mask.py#L305-L315

But, the Masks class needs to account for when the bounds are defined by lat/lon. This is needed when the Mask is used to weight the metric, for example:

https://github.com/icenet-ai/icenet/blob/f1285368eb731ed473c6b574b1d48ae574a8c01e/icenet/plotting/forecast.py#L88-L100