### PR TITLE
Fix #303: Omit lambert_azimuthal_equal_area var when loading nc file

### DIFF
--- a/icenet/data/process.py
+++ b/icenet/data/process.py
@@ -354,7 +354,7 @@ class IceNetPreProcessor(Processor):
             concat_dim="time",
             coords="minimal",
             compat="override",
-            drop_variables=("lat", "lon"),
+            drop_variables=("lat", "lon", "lambert_azimuthal_equal_area"),
             parallel=self._parallel)
 
         # For processing one file, we're going to assume a single non-lambert


### PR DESCRIPTION
Resolves #303 

As per title, omits loading `lambert_azimuthal_equal_area` variable when loading multiple datasets in one go since in some cases, this variable is missing.