### PR TITLE
Fix #309: Set min eccodes version in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cfgrib
 copernicusmarine
 dask
 distributed
-eccodes
+eccodes>2.37.0
 ecmwf-api-client
 h5py>2.10
 ibicus


### PR DESCRIPTION
Resolves #309 

Sets minimum `eccodes` to version that should include binary requirement of `eccodes` along with the python module.