### PR TITLE
Fix #316: Use imageio-ffmpeg ffmpeg binary for matplotlib mp4 output

### DIFF
--- a/icenet/plotting/video.py
+++ b/icenet/plotting/video.py
@@ -6,6 +6,7 @@ import re
 
 from concurrent.futures import as_completed, ProcessPoolExecutor
 
+import imageio_ffmpeg as ffmpeg
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -206,6 +207,9 @@ def xarray_to_video(
         logging.info("Not saving plot, will return animation")
     else:
         logging.info("Saving plot to {}".format(video_path))
+        # Set Matplotlib's ffmpeg executable path to the one from imageio_ffmpeg
+        ffmpeg_path = ffmpeg.get_ffmpeg_exe()
+        plt.rcParams['animation.ffmpeg_path'] = ffmpeg_path
         animation.save(video_path, fps=fps, extra_args=['-vcodec', 'libx264'])
     return animation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ eccodes>2.37.0
 ecmwf-api-client
 h5py>2.10
 ibicus
+imageio-ffmpeg
 matplotlib
 motuclient
 netcdf4<1.6.1


### PR DESCRIPTION
Resolves #316 

As per title, uses `imageio-ffmpeg` library which downloads ffmpeg binaries, and then, in IceNet point to it before saving matplotlib animation.

This allows removal of system/conda ffmpeg dependency.