### PR TITLE
Dev #318: Temporarily use version specification on eccodes to 2.37.0-2.38.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cfgrib
 copernicusmarine
 dask
 distributed
-eccodes>2.37.0
+eccodes>=2.37.0, <2.39.0
 ecmwf-api-client
 h5py>2.10
 ibicus


### PR DESCRIPTION
Temporary fix for eccodes requirements for v0.2.9 release.

Specify version range for eccodes since binary seems to be missing in newer versions `v2.39.0+`