### PR TITLE
Fix temporal lag indexing and propagate variable lag overrides

### DIFF
--- a/icenet/data/loader.py
+++ b/icenet/data/loader.py
@@ -103,6 +103,12 @@ def create():
     args = create_get_args()
     dates = process_date_args(args)
 
+    # Read var_lag_override from loader configuration JSON
+    import orjson
+    with open(args.loader_configuration, 'r') as fh:
+        loader_config = orjson.loads(fh.read())
+    var_lag_override = loader_config.get('var_lag_override', None)
+
     dl = IceNetDataLoaderFactory().create_data_loader(
         args.implementation,
         "loader.{}.json".format(args.name),
@@ -118,7 +124,8 @@ def create():
         pickup=args.pickup,
         generate_workers=args.workers,
         dask_port=args.dask_port,
-        futures_per_worker=args.futures)
+        futures_per_worker=args.futures,
+        var_lag_override=var_lag_override)
 
     if args.cfg:
         dl.write_dataset_config_only()

--- a/icenet/data/loaders/dask.py
+++ b/icenet/data/loaders/dask.py
@@ -396,9 +396,19 @@ def generate_sample(forecast_date: object,
 
     # Prepare data sample
     # To become array of shape (*raw_data_shape, n_forecast_days)
-    forecast_dts = [
-        forecast_date + dt.timedelta(days=n) for n in range(n_forecast_days)
-    ]
+    # For leadtime 1, the target window should start at the next time step,
+    # not the current one; this keeps the model from predicting the initial
+    # date as its own target.
+    if not prediction:
+        forecast_dts = [
+            forecast_date + dt.timedelta(days=n + 1)
+            for n in range(n_forecast_days)
+        ]
+    else:
+        forecast_dts = [
+            forecast_date + dt.timedelta(days=n)
+            for n in range(n_forecast_days)
+        ]
 
     y = da.zeros((*shape, n_forecast_days, 1), dtype=dtype)
     sample_weights = da.zeros((*shape, n_forecast_days, 1), dtype=dtype)
@@ -415,8 +425,7 @@ def generate_sample(forecast_date: object,
         y[:, :, :, 0] = sample_output
 
     # Masked recomposition of output
-    for leadtime_idx in range(n_forecast_days):
-        forecast_day = forecast_date + dt.timedelta(days=leadtime_idx)
+    for leadtime_idx, forecast_day in enumerate(forecast_dts):
 
         if any([forecast_day == missing_date for missing_date in missing_dates]):
             sample_weight = da.zeros(shape, dtype)
@@ -459,8 +468,11 @@ def generate_sample(forecast_date: object,
                 ]
         else:
             channel_ds = var_ds
+            # Keep the current-time point as the most recent lag input instead of
+            # skipping straight to the previous step. This preserves the correct
+            # temporal ordering for lagged inputs.
             channel_dates = [
-                pd.Timestamp(forecast_date - dt.timedelta(days=n+1))
+                pd.Timestamp(forecast_date - dt.timedelta(days=n))
                 for n in range(num_channels)
             ]
 


### PR DESCRIPTION
This PR fixes two related temporal alignment issues in the IceNet data loader:

The forecast target window was effectively aligned to the initialization month instead of the next month, causing systematic off-by-one behavior in training.
The lagged input channels were starting one step too early in the past, producing incorrect temporal context for monthly predictors.
It also propagates [var_lag_override] from the loader configuration JSON into the dataset creation path so per-variable lag settings are respected by icenet_dataset_create.

Previously, the model was seeing the wrong temporal context leading to data leakage and variable lags were not supported. 

