### PR TITLE
Fix/forecast indexing robustness v04

### DIFF
--- a/icenet/data/loader.py
+++ b/icenet/data/loader.py
@@ -100,6 +100,12 @@ def create_network_dataset():
         loader_config = orjson.loads(fh.read())
     var_lag_override = loader_config.get('var_lag_override', None)
 
+    # Read var_lag_override from loader configuration JSON
+    import orjson
+    with open(args.loader_configuration, 'r') as fh:
+        loader_config = orjson.loads(fh.read())
+    var_lag_override = loader_config.get('var_lag_override', None)
+
     dl = IceNetDataLoaderFactory().create_data_loader(
         args.implementation,
         args.loader_configuration,

--- a/icenet/data/loader.py
+++ b/icenet/data/loader.py
@@ -94,6 +94,12 @@ def create_network_dataset():
     """
     args = create_get_args()
 
+    # Read var_lag_override from loader configuration JSON
+    import orjson
+    with open(args.loader_configuration, 'r') as fh:
+        loader_config = orjson.loads(fh.read())
+    var_lag_override = loader_config.get('var_lag_override', None)
+
     dl = IceNetDataLoaderFactory().create_data_loader(
         args.implementation,
         args.loader_configuration,
@@ -105,7 +111,8 @@ def create_network_dataset():
         pickup=args.pickup,
         generate_workers=args.workers,
         dask_port=args.dask_port,
-        futures_per_worker=args.futures)
+        futures_per_worker=args.futures,
+        var_lag_override=var_lag_override)
 
     if args.cfg:
         dl.write_dataset_config_only()

--- a/icenet/data/loaders/dask.py
+++ b/icenet/data/loaders/dask.py
@@ -422,6 +422,19 @@ def generate_sample(forecast_date: object,
 
     # Prepare data sample
     # To become array of shape (*raw_data_shape, n_forecast_steps)
+    # For non-prediction samples, the target window should start after the
+    # current forecast date so the model is not trained to predict its own
+    # initialization point.
+    if not prediction:
+        forecast_steps = [
+            forecast_date + relativedelta(**{relative_attr: n + 1})
+            for n in range(n_forecast_steps)
+        ]
+    else:
+        forecast_steps = [
+            forecast_date + relativedelta(**{relative_attr: n})
+            for n in range(n_forecast_steps)
+        ]
 
     # forecast_base_idx for a prediction does not contain forecast date without multiple
     # dates being forecast, so handle accordingly
@@ -450,8 +463,7 @@ def generate_sample(forecast_date: object,
         y = da.ma.where(y_mask, 0., y)
 
     # Masked recomposition of output
-    for leadtime_idx in range(n_forecast_steps):
-        forecast_step = forecast_date + relativedelta(**{relative_attr: leadtime_idx})
+    for leadtime_idx, forecast_step in enumerate(forecast_steps):
 
         if any([forecast_step == missing_date for missing_date in missing_dates]):
             sample_weight = da.zeros(shape, dtype)
@@ -501,7 +513,9 @@ def generate_sample(forecast_date: object,
         # If we're not a trend, we're a lag channel looking back historically from the initialisation date
         else:
             channel_ds = var_ds
-            channel_idxs = [forecast_base_idx - n for n in range(1, num_channels + 1)]
+            # Keep the current-time point as the most recent lag input instead of
+            # skipping straight to the previous step.
+            channel_idxs = [forecast_base_idx - n for n in range(num_channels)]
 
         channel_data = []
         for idx in channel_idxs:


### PR DESCRIPTION
This PR fixes temporal indexing errors in dataset generation and restores propagation of the per-variable lag override from the loader config.

The issue was twofold:

the loader config value for var_lag_override was not being passed through to the data loader factory
the Dask sample generator used the wrong date offsets for forecast targets and lagged inputs
This could lead to training samples that:

included the initialization date as a target
skipped the most recent lagged observation
mismatched the intended lead-time and lag-time semantics
Changes

Read var_lag_override from the loader configuration JSON in icenet/data/loader.py
Pass var_lag_override through when creating the data loader
Correct off-by-one indexing in icenet/data/loaders/dask.py
Ensure non-prediction targets begin after the current forecast date
Preserve the current time point as the most recent lagged input instead of skipping one step too far back